### PR TITLE
Buttons & Call to Action Links

### DIFF
--- a/wp-content/themes/csisjti/assets/_scss/abstracts/_placeholders.scss
+++ b/wp-content/themes/csisjti/assets/_scss/abstracts/_placeholders.scss
@@ -68,6 +68,7 @@
   font-weight: 500;
   @include font-size(14px);
   line-height: 1.14;
+  text-transform: uppercase;
 }
 
 %font-ui-text-sm-bold-uppercase {

--- a/wp-content/themes/csisjti/assets/_scss/base/_base.scss
+++ b/wp-content/themes/csisjti/assets/_scss/base/_base.scss
@@ -43,3 +43,7 @@ body {
     --container-padding: #{rem(80)};
   }
 }
+
+#site-content {
+  padding-top: var(--header-height);
+}

--- a/wp-content/themes/csisjti/assets/_scss/base/_base.scss
+++ b/wp-content/themes/csisjti/assets/_scss/base/_base.scss
@@ -19,7 +19,7 @@
 }
 
 *:focus {
-  outline: 1px solid #f00;
+  outline: 1px solid $color-primary-blue-500;
 }
 
 html,

--- a/wp-content/themes/csisjti/assets/_scss/components/_buttons.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_buttons.scss
@@ -1,26 +1,23 @@
 @use '../abstracts' as *;
 
 .btn {
-  display: inline-block;
-  padding: rem(8) rem(12);
-  // @extend %font-button;
+  display: inline-flex;
+  padding: rem(8) rem(16);
+  @extend %font-ui-text-sm-uppercase;
+  color: $color-white-190;
   text-align: center;
   text-transform: uppercase;
-  background: transparent;
-  // border: 1px solid $color-primary-dark;
-  border-radius: 3px;
-  transition: color 0.3s ease-in-out, background 0.3s ease-in-out;
+  background: $color-primary-blue-400;
+  border: 1px solid $color-primary-blue-400;
+  border-radius: 2px;
+  transition: color 0.3s ease-in-out, background 0.3s ease-in-out,
+    border 0.3s ease-in-out, filter 0.3s ease-in-out;
 
-  // &:hover {
-  //   color: $color-text-gray-05;
-  //   background: $color-primary-dark-200;
-  //   border: 1px solid $color-primary-dark;
-  // }
-
-  // &:focus {
-  //   outline: none;
-  //   box-shadow: 0 0 0 2px $color-primary-light;
-  // }
+  &:hover {
+    color: $color-white-190;
+    background: $color-primary-blue-200;
+    filter: $shadow--3;
+  }
 
   &:not([disabled]) {
     cursor: pointer;
@@ -29,37 +26,38 @@
   &[disabled] {
     cursor: not-allowed;
   }
-}
 
-// .btn--solid {
-//   color: $color-text-gray-05;
-//   background: $color-primary-dark;
+  &--outline {
+    color: $color-primary-blue-300;
+    background: transparent;
+    border: 1px solid $color-primary-blue-500;
 
-//   &:focus {
-//     color: $color-text-gray-05;
-//   }
-// }
+    &:hover {
+      border-color: $color-primary-blue-200;
+    }
+  }
 
-// .btn--outline {
-//   color: $color-primary-dark;
-//   background: transparent;
-// }
+  &--round {
+    border-radius: 50px;
+  }
 
-// .btn--gray {
-//   color: $color-white-100;
-//   background: $color-primary-darkest;
+  &--circle {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border-radius: 50%;
+  }
 
-//   &:focus {
-//     color: $color-white-100;
-//   }
-// }
+  .icon {
+    &:first-child {
+      margin-right: rem(4);
+    }
 
-.btn--circle {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border-radius: 50%;
+    &:last-child {
+      margin-left: rem(4);
+    }
+  }
 }

--- a/wp-content/themes/csisjti/assets/_scss/components/_cta.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_cta.scss
@@ -1,0 +1,43 @@
+@use '../abstracts' as *;
+
+.cta {
+  --text-color: #{$color-primary-blue-300};
+  --icon-color: var(--text-color);
+  --icon-border-color: #{$color-primary-blue-600};
+  display: inline-flex;
+  align-items: center;
+  @extend %font-ui-text-lg-bold;
+  color: var(--text-color);
+
+  &:hover {
+    --icon-color: #{$color-white-190};
+    --icon-fill: #{$color-primary-blue-400};
+    --icon-border-color: var(--icon-fill);
+    color: var(--text-color);
+
+    .icon {
+      background: var(--icon-fill);
+    }
+  }
+
+  &--white {
+    --text-color: #{$color-white-190};
+    --icon-border-color: #{$color-white-155};
+
+    &:hover {
+      --text-color: #{$color-white-100};
+      --icon-color: #{$color-primary-blue-300};
+      --icon-fill: var(--text-color);
+      --icon-border-color: var(--text-color);
+    }
+  }
+
+  .icon {
+    margin-left: rem(12);
+    color: var(--icon-color);
+    font-size: 1.6em;
+    border: 2px solid var(--icon-border-color);
+    border-radius: 50%;
+    transition: background 0.3s ease-in-out, border 0.3s ease-in-out;
+  }
+}

--- a/wp-content/themes/csisjti/assets/_scss/style.scss
+++ b/wp-content/themes/csisjti/assets/_scss/style.scss
@@ -5,6 +5,7 @@
 @use 'base/typography';
 @use 'base/utilities';
 @use 'components/buttons';
+@use 'components/cta';
 @use 'components/media';
 @use 'components/post-block';
 @use 'components/post-meta';

--- a/wp-content/themes/csisjti/assets/static/icons.svg
+++ b/wp-content/themes/csisjti/assets/static/icons.svg
@@ -10,6 +10,10 @@
 <path fill="none" stroke="#018085" style="stroke: var(--color1, #018085)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="4" stroke-width="2.6667" d="M16 21.333l5.333-5.333-5.333-5.333"></path>
 <path fill="none" stroke="#018085" style="stroke: var(--color1, #018085)" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="4" stroke-width="2.6667" d="M10.667 16h10.667"></path>
 </symbol>
+<symbol id="icon-arrow-right" viewBox="0 0 32 32">
+<path fill="none" stroke="currentColor" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="4" stroke-width="2.6667" d="M16 21.333l5.333-5.333-5.333-5.333"></path>
+<path fill="none" stroke="currentColor" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="4" stroke-width="2.6667" d="M10.667 16h10.667"></path>
+</symbol>
 <symbol id="icon-info" viewBox="0 0 32 32">
 <path fill="#018085" style="fill: var(--color1, #018085)" d="M16 0c-8.822 0-16 7.178-16 16s7.178 16 16 16c8.822 0 16-7.178 16-16s-7.178-16-16-16zM16 28.8c-7.058 0-12.8-5.742-12.8-12.8s5.742-12.8 12.8-12.8c7.058 0 12.8 5.742 12.8 12.8s-5.742 12.8-12.8 12.8z"></path>
 <path fill="#018085" style="fill: var(--color1, #018085)" d="M14.4 14.4h3.2v9.6h-3.2v-9.6zM14.4 8h3.2v3.2h-3.2v-3.2z"></path>

--- a/wp-content/themes/csisjti/front-page.php
+++ b/wp-content/themes/csisjti/front-page.php
@@ -45,6 +45,28 @@ get_header();
 	echo csisjti_get_svg( 'videocam' );
 	?>
 
+	<button class="btn">Default Button</button>
+	<button class="btn btn--round">Filled Round</button>
+	<button class="btn btn--round">
+		<?php
+	echo csisjti_get_svg( 'filter' );
+	?>
+		Text Icons
+		<?php
+	echo csisjti_get_svg( 'arrow-down' );
+	?>
+	</button>
+	<button class="btn btn--outline">Test Outline</button>
+	<button class="btn btn--outline btn--round">
+		<?php
+	echo csisjti_get_svg( 'filter' );
+	?>
+		Less Details
+		<?php
+	echo csisjti_get_svg( 'arrow-down' );
+	?>
+	</button>
+
 </main><!-- #site-content -->
 
 <?php get_footer(); ?>

--- a/wp-content/themes/csisjti/front-page.php
+++ b/wp-content/themes/csisjti/front-page.php
@@ -66,6 +66,16 @@ get_header();
 	echo csisjti_get_svg( 'arrow-down' );
 	?>
 	</button>
+	<br /><br />
+	<a href="" class="cta">What is "Just Transition"? <?php
+	echo csisjti_get_svg( 'arrow-right' );
+	?></a>
+	<br /><br />
+	<div style="background: #ccc;">
+		<a href="" class="cta cta--white">What is "Just Transition"? <?php
+	echo csisjti_get_svg( 'arrow-right' );
+	?></a>
+	</div>
 
 </main><!-- #site-content -->
 


### PR DESCRIPTION
Closes #6, pending Tucker's response to my question about focus styles (right now it defaults to the site standard). It also includes styling for the "call to action" links.

## Button Styles
- `btn`: Solid green button
- `btn btn--outline`: Transparent button with green outline
- `btn btn--round`: Solid green button with pill shape
- `btn btn--outline btn--round`: Transparent button with green outline and pill shape