### PR TITLE
Implements Resource Block

### DIFF
--- a/wp-content/themes/csisjti/archive-resource-library.php
+++ b/wp-content/themes/csisjti/archive-resource-library.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * The template for displaying single posts and pages.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package CSIS iLab
+ * @subpackage @package CSISJTI
+ * @since 1.0.0
+ */
+
+get_header();
+?>
+
+<main id="site-content" role="main">
+	This is the resource library.
+
+	<?php
+
+	if ( have_posts() ) {
+
+		while ( have_posts() ) {
+			the_post();
+
+			get_template_part( 'template-parts/block-post', get_post_type() );
+		}
+	}
+
+	?>
+
+</main><!-- #site-content -->
+
+<?php get_footer(); ?>

--- a/wp-content/themes/csisjti/assets/_scss/abstracts/_placeholders.scss
+++ b/wp-content/themes/csisjti/assets/_scss/abstracts/_placeholders.scss
@@ -75,11 +75,13 @@
   font-weight: 700;
   @include font-size(14px);
   line-height: 1;
+  text-transform: uppercase;
 }
 
 %font-ui-text-md-bold-uppercase {
   @include font-size(16px);
   line-height: 1.35;
+  text-transform: uppercase;
 }
 
 %font-ui-text-lg-bold-uppercase {
@@ -87,6 +89,7 @@
   font-weight: 700;
   @include font-size(18px);
   line-height: 1.14;
+  text-transform: uppercase;
 }
 
 %font-ui-text-md-bold-barlow {

--- a/wp-content/themes/csisjti/assets/_scss/abstracts/_variables.scss
+++ b/wp-content/themes/csisjti/assets/_scss/abstracts/_variables.scss
@@ -83,3 +83,6 @@ $size__content-wide-max-width: 1120px;
 $shadow--3: drop-shadow(0 3px 4px rgba(2, 3, 3, 0.03))
   drop-shadow(0 3px 3px rgba(2, 3, 3, 0.02))
   drop-shadow(0 1px 8px rgba(2, 3, 3, 0.04));
+
+$shadow--4: 0 4px 5px rgba(2, 3, 3, 0.03), 0 1px 10px rgba(2, 3, 3, 0.02),
+  0 2px 4px rgba(2, 3, 3, 0.04);

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block-post.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block-post.scss
@@ -1,0 +1,76 @@
+@use 'abstracts' as *;
+
+.post-block--post {
+  --meta-categories: #{$color-primary-green-300};
+
+  $post: '.post-block';
+
+  display: grid;
+  grid-template-areas:
+    'img'
+    'category'
+    'title'
+    'date'
+    'excerpt';
+  grid-template-columns: 1fr;
+  margin-right: auto;
+  margin-left: auto;
+
+  @include breakpoint('small') {
+    grid-template-areas:
+      'img category'
+      'img title'
+      'img date'
+      'img excerpt';
+    grid-template-columns: 25% minmax(min-content, 680px);
+    grid-template-rows: max-content max-content max-content auto;
+    width: fit-content;
+    column-gap: rem(32);
+  }
+
+  @include breakpoint('large') {
+    column-gap: rem(40);
+  }
+
+  #{$post}__category {
+    grid-area: category;
+    @extend %font-ui-text-sm;
+  }
+
+  #{$post}__title {
+    grid-area: title;
+  }
+
+  #{$post}__img {
+    display: block;
+    grid-area: img;
+    margin-bottom: rem(24);
+
+    @include breakpoint('small') {
+      margin-bottom: 0;
+    }
+
+    img {
+      max-height: 180px;
+      object-fit: cover;
+
+      @include breakpoint('small') {
+        max-height: unset;
+        object-fit: unset;
+      }
+
+      @include breakpoint('large') {
+        width: 100%;
+        max-width: 320px;
+      }
+    }
+  }
+
+  #{$post}__excerpt {
+    grid-area: excerpt;
+  }
+
+  .post-meta__date {
+    grid-area: date;
+  }
+}

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block-post.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block-post.scss
@@ -39,6 +39,7 @@
 
   #{$post}__title {
     grid-area: title;
+    margin-bottom: rem(8px);
   }
 
   #{$post}__img {
@@ -72,5 +73,6 @@
 
   .post-meta__date {
     grid-area: date;
+    margin-bottom: rem(16);
   }
 }

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
@@ -1,0 +1,5 @@
+@use 'abstracts' as *;
+
+.post-block--resource-library {
+  $post: '.post-block';
+}

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
@@ -1,5 +1,182 @@
 @use 'abstracts' as *;
 
 .post-block--resource-library {
+  --padding-sides: #{rem(20)};
   $post: '.post-block';
+
+  position: relative;
+  max-width: 795px;
+  margin-right: auto;
+  margin-left: auto;
+  padding: rem(24) var(--padding-sides) rem(40);
+  background: $color-white-100;
+
+  @include breakpoint('large') {
+    --padding-sides: #{rem(32)};
+  }
+
+  @include breakpoint('xlarge') {
+    --padding-sides: #{rem(40)};
+  }
+
+  &.is-essential-reading::before,
+  &.is-jti-content::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: var(--padding-sides);
+    width: 16px;
+    height: 24px;
+    border: 8px solid var(--color, $color-primary-yellow-400);
+    border-top: 0;
+    border-bottom: 6px solid transparent;
+  }
+
+  &.is-essential-reading::before {
+    --color: #{$color-primary-green-500};
+  }
+
+  &.is-jti-content {
+    &.is-essential-reading::before {
+      right: calc(var(--padding-sides) + 1.5rem);
+    }
+  }
+
+  #{$post}__header {
+    margin: rem(16) 0;
+  }
+
+  #{$post}__desc {
+    margin-bottom: rem(24);
+    padding-bottom: rem(16);
+    color: $color-black-190;
+    @extend %font-copy-body-short-md;
+    border-bottom: 1px solid $color-gray-100;
+  }
+
+  #{$post}__meta,
+  #{$post}__details-content {
+    display: grid;
+    row-gap: rem(24);
+
+    @include breakpoint('large') {
+      grid-template-columns: repeat(2, 1fr);
+      column-gap: rem(32);
+    }
+  }
+
+  .post-meta {
+    &__label {
+      margin-bottom: rem(6);
+      color: $color-primary-green-400;
+      @extend %font-ui-text-sm-bold-uppercase;
+    }
+
+    &__value {
+      @extend %font-ui-body-md;
+    }
+
+    &__categories {
+      margin-bottom: rem(16);
+    }
+
+    &__date {
+      margin-bottom: rem(8);
+    }
+  }
+
+  #{$post}__details {
+    grid-column: 1 / -1;
+
+    summary {
+      display: flex;
+      width: fit-content;
+      margin: 0 auto;
+      list-style: none;
+
+      @include breakpoint('large') {
+        margin-left: 0;
+      }
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+    }
+
+    &-label::after {
+      content: attr(data-open);
+      margin-right: 4px;
+    }
+
+    &[open] {
+      summary {
+        margin-bottom: rem(24);
+        color: $color-white-190;
+        background: $color-primary-blue-400;
+        border: 1px solid $color-primary-blue-400;
+
+        /* stylelint-disable-next-line */
+        &:hover {
+          background: $color-primary-blue-200;
+        }
+
+        /* stylelint-disable-next-line */
+        .icon {
+          transform: rotate(180deg);
+        }
+      }
+
+      .post-block__details-label::after {
+        content: attr(data-close);
+      }
+    }
+  }
+
+  #{$post}__focus,
+  #{$post}__keywords,
+  #{$post}__summary {
+    @include breakpoint('large') {
+      grid-column: 1 / -1;
+    }
+  }
+
+  #{$post}__focus {
+    &-content {
+      @include breakpoint('large') {
+        columns: 2;
+        column-gap: rem(32);
+      }
+    }
+
+    .post-meta__value {
+      display: list-item;
+      margin-bottom: rem(4);
+      margin-left: rem(16);
+      padding-left: 0;
+      break-inside: avoid;
+    }
+  }
+
+  #{$post}__keywords {
+    padding-bottom: rem(32);
+    border-bottom: 1px solid $color-gray-100;
+
+    @include breakpoint('large') {
+      display: grid;
+      grid-template-columns: max-content auto;
+      column-gap: rem(24);
+    }
+  }
+
+  #{$post}__pill-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: rem(6);
+  }
+
+  #{$post}__summary {
+    margin-top: rem(8);
+    color: $color-black-190;
+    @extend %font-copy-body-long-lg;
+  }
 }

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
@@ -1,6 +1,7 @@
 @use 'abstracts' as *;
 
 .post-block--resource-library {
+  --margin-between: #{rem(40)};
   --padding-sides: #{rem(20)};
   $post: '.post-block';
 
@@ -10,6 +11,7 @@
   margin-left: auto;
   padding: rem(24) var(--padding-sides) rem(40);
   background: $color-white-100;
+  box-shadow: $shadow--4;
 
   @include breakpoint('large') {
     --padding-sides: #{rem(32)};
@@ -17,6 +19,13 @@
 
   @include breakpoint('xlarge') {
     --padding-sides: #{rem(40)};
+  }
+
+  &.is-essential-reading,
+  &.is-jti-content {
+    #{$post}__header {
+      margin-top: rem(16);
+    }
   }
 
   &.is-essential-reading::before,
@@ -43,7 +52,33 @@
   }
 
   #{$post}__header {
-    margin: rem(16) 0;
+    margin: 0 0 rem(16);
+  }
+
+  #{$post}__title {
+    /* stylelint-disable */
+    a[href*="//"]:not([href*="energy-jti.local"]):not([href*="localhost"]):not([href*="justtransitioninitiative"])
+    {
+      /* stylelint-enable */
+      &::after {
+        content: '';
+        position: relative;
+        bottom: 3px;
+        display: inline-block;
+        width: 0.8em;
+        height: 0.8em;
+        background-image: url('/wp-content/themes/csisjti/assets/static/icons/arrow-external.svg');
+        background-size: 100% 100%;
+        opacity: 0.55;
+        transition: opacity 0.3s ease-in-out, filter 0.3s ease-in-out;
+      }
+
+      &:hover::after {
+        opacity: 1;
+        filter: invert(22%) sepia(46%) saturate(1699%) hue-rotate(150deg)
+          brightness(98%) contrast(104%);
+      }
+    }
   }
 
   #{$post}__desc {
@@ -85,53 +120,6 @@
     }
   }
 
-  #{$post}__details {
-    grid-column: 1 / -1;
-
-    summary {
-      display: flex;
-      width: fit-content;
-      margin: 0 auto;
-      list-style: none;
-
-      @include breakpoint('large') {
-        margin-left: 0;
-      }
-
-      &::-webkit-details-marker {
-        display: none;
-      }
-    }
-
-    &-label::after {
-      content: attr(data-open);
-      margin-right: 4px;
-    }
-
-    &[open] {
-      summary {
-        margin-bottom: rem(24);
-        color: $color-white-190;
-        background: $color-primary-blue-400;
-        border: 1px solid $color-primary-blue-400;
-
-        /* stylelint-disable-next-line */
-        &:hover {
-          background: $color-primary-blue-200;
-        }
-
-        /* stylelint-disable-next-line */
-        .icon {
-          transform: rotate(180deg);
-        }
-      }
-
-      .post-block__details-label::after {
-        content: attr(data-close);
-      }
-    }
-  }
-
   #{$post}__focus,
   #{$post}__keywords,
   #{$post}__summary {
@@ -151,7 +139,7 @@
     .post-meta__value {
       display: list-item;
       margin-bottom: rem(4);
-      margin-left: rem(16);
+      margin-left: rem(18);
       padding-left: 0;
       break-inside: avoid;
     }
@@ -178,5 +166,52 @@
     margin-top: rem(8);
     color: $color-black-190;
     @extend %font-copy-body-long-lg;
+  }
+}
+
+.post-block__details {
+  grid-column: 1 / -1;
+
+  summary {
+    display: flex;
+    width: fit-content;
+    margin: rem(12) auto 0;
+    list-style: none;
+
+    @include breakpoint('large') {
+      margin-left: 0;
+    }
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+
+  &-label::after {
+    content: attr(data-open);
+    margin-right: 4px;
+  }
+
+  &[open] {
+    summary {
+      margin-bottom: rem(40);
+      color: $color-white-190;
+      background: $color-primary-blue-400;
+      border: 1px solid $color-primary-blue-400;
+
+      /* stylelint-disable-next-line */
+      &:hover {
+        background: $color-primary-blue-200;
+      }
+
+      /* stylelint-disable-next-line */
+      .icon {
+        transform: rotate(180deg);
+      }
+    }
+
+    .post-block__details-label::after {
+      content: attr(data-close);
+    }
   }
 }

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block.scss
@@ -8,7 +8,6 @@
   }
 
   &__title {
-    margin-bottom: rem(8px);
     color: $color-black-100;
     @extend %font-ui-headline-lg;
     text-decoration: underline;
@@ -22,9 +21,5 @@
   &__excerpt {
     color: $color-black-190;
     @extend %font-ui-body-md;
-  }
-
-  .post-meta__date {
-    margin-bottom: rem(16);
   }
 }

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block.scss
@@ -1,4 +1,6 @@
 @use 'abstracts' as *;
+@use 'post-block-post';
+@use 'post-block-resource-library';
 
 .post-block {
   + .post-block {
@@ -24,80 +26,5 @@
 
   .post-meta__date {
     margin-bottom: rem(16);
-  }
-}
-
-.post-block--post {
-  --meta-categories: #{$color-primary-green-300};
-
-  $post: '.post-block';
-
-  display: grid;
-  grid-template-areas:
-    'img'
-    'category'
-    'title'
-    'date'
-    'excerpt';
-  grid-template-columns: 1fr;
-  margin-right: auto;
-  margin-left: auto;
-
-  @include breakpoint('small') {
-    grid-template-areas:
-      'img category'
-      'img title'
-      'img date'
-      'img excerpt';
-    grid-template-columns: 25% minmax(min-content, 680px);
-    grid-template-rows: max-content max-content max-content auto;
-    width: fit-content;
-    column-gap: rem(32);
-  }
-
-  @include breakpoint('large') {
-    column-gap: rem(40);
-  }
-
-  #{$post}__category {
-    grid-area: category;
-    @extend %font-ui-text-sm;
-  }
-
-  #{$post}__title {
-    grid-area: title;
-  }
-
-  #{$post}__img {
-    display: block;
-    grid-area: img;
-    margin-bottom: rem(24);
-
-    @include breakpoint('small') {
-      margin-bottom: 0;
-    }
-
-    img {
-      max-height: 180px;
-      object-fit: cover;
-
-      @include breakpoint('small') {
-        max-height: unset;
-        object-fit: unset;
-      }
-
-      @include breakpoint('large') {
-        width: 100%;
-        max-width: 320px;
-      }
-    }
-  }
-
-  #{$post}__excerpt {
-    grid-area: excerpt;
-  }
-
-  .post-meta__date {
-    grid-area: date;
   }
 }

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block.scss
@@ -4,17 +4,20 @@
 
 .post-block {
   + .post-block {
-    margin-top: rem(56);
+    margin-top: var(--margin-between, rem(56));
   }
 
   &__title {
     color: $color-black-100;
     @extend %font-ui-headline-lg;
-    text-decoration: underline;
 
-    &:hover {
-      color: $color-primary-blue-200;
-      text-decoration: none;
+    a {
+      text-decoration: underline;
+
+      &:hover {
+        color: $color-primary-blue-200;
+        text-decoration: none;
+      }
     }
   }
 

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-meta.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-meta.scss
@@ -13,4 +13,12 @@
     color: var(--meta-categories);
     font-weight: bold;
   }
+
+  &__pill {
+    width: fit-content;
+    padding: rem(4) rem(16);
+    line-height: 1.15;
+    background: $color-gray-200;
+    border-radius: 30px;
+  }
 }

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-meta.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-meta.scss
@@ -21,4 +21,9 @@
     background: $color-gray-200;
     border-radius: 30px;
   }
+
+  &__subvalue {
+    color: $color-black-155;
+    @extend %font-ui-body-sm;
+  }
 }

--- a/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
@@ -1,5 +1,5 @@
 @use '../abstracts' as *;
 
 .post-type-archive-resource-library {
-  background: $color-gray-200;
+  background: $color-gray-100;
 }

--- a/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
@@ -1,0 +1,5 @@
+@use '../abstracts' as *;
+
+.post-type-archive-resource-library {
+  background: $color-gray-200;
+}

--- a/wp-content/themes/csisjti/functions.php
+++ b/wp-content/themes/csisjti/functions.php
@@ -196,6 +196,10 @@ function csisjti_register_styles() {
 		wp_enqueue_style( 'csisjti-style-archive', get_stylesheet_directory_uri() . '/assets/css/pages/archive.min.css', array(), $theme_version );
 	}
 
+	if ( is_post_type_archive( 'resource-library' ) ) {
+		wp_enqueue_style( 'csisjti-style-resource-library', get_stylesheet_directory_uri() . '/assets/css/pages/resource-library.min.css', array(), $theme_version );
+	}
+
 	if ( is_singular() ) {
 		wp_enqueue_style( 'csisjti-style-single', get_stylesheet_directory_uri() . '/assets/css/pages/single.min.css', array(), $theme_version );
 	}

--- a/wp-content/themes/csisjti/inc/template-tags.php
+++ b/wp-content/themes/csisjti/inc/template-tags.php
@@ -272,6 +272,63 @@ if (! function_exists('csisjti_share')) :
 endif;
 
 /**
+ * Displays Resource Publication Date.
+ *
+ *
+ * @return string $html The publication date.
+ */
+if (! function_exists('csisjti_resource_date')) :
+	function csisjti_resource_date() {
+		$publication_date = get_field( 'publication_date' );
+
+		if ( !$publication_date ) {
+			return;
+		}
+
+		printf( '<div class="post-meta post-meta__date">' . esc_html__( '%1$s', 'csisjti' ) . '</div>', $publication_date ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+/**
+ * Displays Resource Description.
+ *
+ *
+ * @return string $html The description.
+ */
+if (! function_exists('csisjti_resource_description')) :
+	function csisjti_resource_description() {
+		$description = get_field( 'description' );
+
+		if ( !$description ) {
+			return;
+		}
+
+		printf( '<div class="post-block__desc">' . esc_html__( '%1$s', 'csisjti' ) . '</div>', $description ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+/**
+ * Displays Resource Summary.
+ *
+ *
+ * @return string $html The summary.
+ */
+if (! function_exists('csisjti_resource_summary')) :
+	function csisjti_resource_summary() {
+		$summary = get_field( 'summary' );
+
+		if ( !$summary ) {
+			return;
+		}
+
+		printf( '<div class="post-block__summary"><dt class="post-meta__label">Summary</dt><dd class="post-block__summary-content">' . esc_html__( '%1$s', 'csisjti' ) . '</dd></div>', $summary ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+/**
  * Displays Resource Authors.
  *
  *
@@ -290,7 +347,6 @@ if (! function_exists('csisjti_resource_authors')) :
 			$authors[] = $author->name;
 		}
 
-		/* translators: 1: list of tags. */
 		printf( '<div class="post-block__authors"><dt class="post-meta__label">By</dt><dd class="post-meta__value">' . esc_html__( '%1$s', 'csisjti' ) . '</dd></div>', implode(', ', $authors ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	}
@@ -326,7 +382,6 @@ if (! function_exists('csisjti_resource_organization')) :
 			$organizations_type[] = $organization_type->name;
 		}
 
-		/* translators: 1: list of tags. */
 		printf( '<div class="post-block__organizations"><dt class="post-meta__label">Publishing Organization</dt><dd class="post-meta__value">' . esc_html__( '%1$s', 'csisjti' ) . '<div class="post-meta__subvalue">' . esc_html__( '%2$s', 'csisjti' ) . '</div></dd></div>', implode(', ', $organizations ), implode(', ', $organizations_type ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	}
@@ -351,8 +406,133 @@ if (! function_exists('csisjti_resource_format')) :
 			$formats[] = $term->name;
 		}
 
-		/* translators: 1: list of tags. */
-		printf( '<div class="post-meta post-block__format">' . esc_html__( '%1$s', 'csisjti' ) . '</div>', implode('/ ', $formats ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		printf( '<div class="post-meta post-meta__categories">' . esc_html__( '%1$s', 'csisjti' ) . '</div>', implode('/ ', $formats ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	}
+endif;
+
+/**
+ * Displays Resource Sectors.
+ *
+ *
+ * @return string $html The sectors.
+ */
+if (! function_exists('csisjti_resource_sectors')) :
+	function csisjti_resource_sectors() {
+		$sectors = get_field( 'sectors' );
+
+		if ( !$sectors ) {
+			return;
+		}
+
+		$items = '';
+		foreach( $sectors as $term ) {
+			$items .= '<dd class="post-meta__pill">' . $term->name . '</dd>';
+		}
+
+		printf( '<div class="post-block__sectors"><dt class="post-meta__label">Sectors</dt><div class="post-meta__value post-block__pill-container">' . esc_html__( '%1$s', 'csisjti' ) . '</div></div>', $items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+/**
+ * Displays Resource Keywords.
+ *
+ *
+ * @return string $html The keywords.
+ */
+if (! function_exists('csisjti_resource_keywords')) :
+	function csisjti_resource_keywords() {
+		$keywords = get_field( 'keywords' );
+
+		if ( !$keywords ) {
+			return;
+		}
+
+		$items = '';
+		foreach( $keywords as $term ) {
+			$items .= '<dd class="post-meta__pill">' . $term->name . '</dd>';
+		}
+
+		printf( '<div class="post-block__keywords"><dt class="post-meta__label">Keywords</dt><div class="post-meta__value post-block__pill-container">' . esc_html__( '%1$s', 'csisjti' ) . '</div></div>', $items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+/**
+ * Displays Resource Geographic Focus.
+ *
+ *
+ * @return string $html The geographic foci.
+ */
+if (! function_exists('csisjti_resource_geographic_focus')) :
+	function csisjti_resource_geographic_focus() {
+		$geographic_focus = get_field( 'geographic_focus' );
+
+		if ( !$geographic_focus ) {
+			return;
+		}
+
+		// Group by parent term
+		$html = csisjti_group_acf_tax_by_parent( $geographic_focus );
+
+		printf( '<div class="post-block__geographic"><dt class="post-meta__label">Geographic Scope</dt><div class="post-meta__value">' . esc_html__( '%1$s', 'csisjti' ) . '</div></div>', $html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+/**
+ * Displays Resource Focus Areas.
+ *
+ *
+ * @return string $html The focus areas.
+ */
+if (! function_exists('csisjti_resource_focus_areas')) :
+	function csisjti_resource_focus_areas() {
+		$focus_areas = get_field( 'focus_areas' );
+
+		if ( !$focus_areas ) {
+			return;
+		}
+
+		// Group by parent term
+		$html = csisjti_group_acf_tax_by_parent( $focus_areas );
+
+		/* translators: 1: list of tags. */
+		printf( '<div class="post-block__focus"><dt class="post-meta__label">Focus Areas</dt><div class="post-block__focus-content">' . esc_html__( '%1$s', 'csisjti' ) . '</div></div>', $html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+/**
+ * Groups taxonomy terms made with ACF by their parent term. Specifically for the Resources Library post block.
+ *
+ *
+ * @return string $html The grouped terms in a defintion term.
+ */
+if (! function_exists('csisjti_group_acf_tax_by_parent')) :
+function csisjti_group_acf_tax_by_parent( $field ) {
+	// Group by parent term
+	$terms = array();
+	foreach( $field as $term ) {
+		if ($term->parent) {
+			$terms[$term->parent]['children'][] = $term->name;
+		} else {
+			$terms[$term->term_id]['parent'] = $term->name;
+		}
+	}
+
+	$html = '';
+	foreach( $terms as $term ) {
+		$html .= '<dd class="post-meta__value">' . $term['parent'];
+
+		if ($term['children']) {
+			$html .= ' > ' . implode(', ', $term['children']);
+		}
+
+		$html .='</dd>';
+	}
+
+	return $html;
+}
 endif;

--- a/wp-content/themes/csisjti/inc/template-tags.php
+++ b/wp-content/themes/csisjti/inc/template-tags.php
@@ -473,10 +473,24 @@ if (! function_exists('csisjti_resource_geographic_focus')) :
 			return;
 		}
 
-		// Group by parent term
-		$html = csisjti_group_acf_tax_by_parent( $geographic_focus );
+		// Global term always goes first & only show child terms.
+		$terms = array();
+		$global = '';
+		foreach( $geographic_focus as $term ) {
+			if ( $term->term_id == 86 ) {
+				$global = $term->name;
+			} elseif ( $term->parent != 0 ) {
+				$terms[] = $term->name;
+			}
+		}
+		sort($terms);
 
-		printf( '<div class="post-block__geographic"><dt class="post-meta__label">Geographic Scope</dt><div class="post-meta__value">' . esc_html__( '%1$s', 'csisjti' ) . '</div></div>', $html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		if ($global) {
+			array_unshift($terms, $global);
+		}
+
+
+		printf( '<div class="post-block__geographic"><dt class="post-meta__label">Geographic Scope</dt><div class="post-meta__value">' . esc_html__( '%1$s', 'csisjti' ) . '</div></div>', implode( ', ', $terms ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	}
 endif;

--- a/wp-content/themes/csisjti/inc/template-tags.php
+++ b/wp-content/themes/csisjti/inc/template-tags.php
@@ -270,3 +270,89 @@ if (! function_exists('csisjti_share')) :
 		}
 	}
 endif;
+
+/**
+ * Displays Resource Authors.
+ *
+ *
+ * @return string $html The authors.
+ */
+if (! function_exists('csisjti_resource_authors')) :
+	function csisjti_resource_authors() {
+		$resource_author = get_field( 'resource_author' );
+
+		if ( !$resource_author ) {
+			return;
+		}
+
+		$authors = array();
+		foreach( $resource_author as $author ) {
+			$authors[] = $author->name;
+		}
+
+		/* translators: 1: list of tags. */
+		printf( '<div class="post-block__authors"><dt class="post-meta__label">By</dt><dd class="post-meta__value">' . esc_html__( '%1$s', 'csisjti' ) . '</dd></div>', implode(', ', $authors ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+/**
+ * Displays Resource Organizations & Types.
+ *
+ *
+ * @return string $html The organizations & types.
+ */
+if (! function_exists('csisjti_resource_organization')) :
+	function csisjti_resource_organization() {
+		$publishing_organization = get_field( 'publishing_organization' );
+
+		if ( !$publishing_organization ) {
+			return;
+		}
+
+		$organizations = array();
+		foreach( $publishing_organization as $organization ) {
+			$organizations[] = $organization->name;
+		}
+
+		$publishing_organization_type = get_field( 'publishing_organization_type' );
+
+		if ( !$publishing_organization_type ) {
+			return;
+		}
+
+		$organizations_type = array();
+		foreach( $publishing_organization_type as $organization_type ) {
+			$organizations_type[] = $organization_type->name;
+		}
+
+		/* translators: 1: list of tags. */
+		printf( '<div class="post-block__organizations"><dt class="post-meta__label">Publishing Organization</dt><dd class="post-meta__value">' . esc_html__( '%1$s', 'csisjti' ) . '<div class="post-meta__subvalue">' . esc_html__( '%2$s', 'csisjti' ) . '</div></dd></div>', implode(', ', $organizations ), implode(', ', $organizations_type ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+/**
+ * Displays Resource Format.
+ *
+ *
+ * @return string $html The format.
+ */
+if (! function_exists('csisjti_resource_format')) :
+	function csisjti_resource_format() {
+		$format = get_field( 'format' );
+
+		if ( !$format ) {
+			return;
+		}
+
+		$formats = array();
+		foreach( $format as $term ) {
+			$formats[] = $term->name;
+		}
+
+		/* translators: 1: list of tags. */
+		printf( '<div class="post-meta post-block__format">' . esc_html__( '%1$s', 'csisjti' ) . '</div>', implode('/ ', $formats ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;

--- a/wp-content/themes/csisjti/inc/template-tags.php
+++ b/wp-content/themes/csisjti/inc/template-tags.php
@@ -323,7 +323,7 @@ if (! function_exists('csisjti_resource_summary')) :
 			return;
 		}
 
-		printf( '<div class="post-block__summary"><dt class="post-meta__label">Summary</dt><dd class="post-block__summary-content">' . esc_html__( '%1$s', 'csisjti' ) . '</dd></div>', $summary ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		printf( '<div class="post-block__summary post-content"><dt class="post-meta__label">Summary</dt><dd class="post-block__summary-content">' . esc_html__( '%1$s', 'csisjti' ) . '</dd></div>', $summary ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 	}
 endif;

--- a/wp-content/themes/csisjti/template-parts/block-post-resource-library.php
+++ b/wp-content/themes/csisjti/template-parts/block-post-resource-library.php
@@ -21,34 +21,51 @@
 ?>
 
 <article <?php post_class($classes); ?> id="post-<?php the_ID(); ?>">
-
+ <header class="post-block__header">
 	<?php
 		csisjti_resource_format();
+
+		csisjti_resource_date();
+
+		$url = get_field( 'url' );
+
+		if ( !$url ) {
+			the_title( '<h2 class="post-block__title">', '</h2>' );
+		} else {
+			the_title( '<h2 class="post-block__title"><a href="' . esc_url( $url ) . '">', '</a></h2>' );
+		}
 	?>
+	</header>
 
-	<?php
+	<?php csisjti_resource_description(); ?>
 
-	the_field( 'publication_date' );
+	<dl class="post-block__meta">
+		<?php
+			csisjti_resource_geographic_focus();
 
-	$url = get_field( 'url' );
+			csisjti_resource_sectors();
+		?>
 
-	if ( !$url ) {
-		the_title( '<h2 class="post-block__title">', '</h2>' );
-	} else {
-		the_title( '<h2 class="post-block__title"><a href="' . esc_url( $url ) . '">', '</a></h2>' );
-	}
+		<details class="post-block__details">
+			<summary class="btn btn--outline btn--round" data-close="Less Details">
+				<span class="post-block__details-label" data-open="More" data-close="Less"></span>Details
+				<?php echo csisjti_get_svg( 'arrow-down' ); ?>
+			</summary>
+			<div class="post-block__details-content">
 
+			<?php
+				csisjti_resource_focus_areas();
 
-	csisjti_resource_authors();
+				csisjti_resource_keywords();
 
-	csisjti_resource_organization();
+				csisjti_resource_authors();
 
-	the_field( 'description' );
+				csisjti_resource_organization();
 
-	the_field( 'summary' );
-
-	?>
-
-	<p class="post-block__excerpt"> <?php echo get_the_excerpt(); ?></p>
+				csisjti_resource_summary();
+			?>
+			</div>
+		</details>
+	</dl>
 
 </article>

--- a/wp-content/themes/csisjti/template-parts/block-post-resource-library.php
+++ b/wp-content/themes/csisjti/template-parts/block-post-resource-library.php
@@ -8,25 +8,44 @@
  * @since 1.0.0
  */
 
+ $classes = 'post-block post-block--resource-library';
+
+ if ( get_field( 'is_essential_reading' ) == 1 ) {
+	$classes .= ' is-essential-reading';
+ }
+
+ if ( get_field( 'is_just_transition_initiative_content' ) == 1 ) {
+	 $classes .= ' is-jti-content';
+ }
+
 ?>
 
-<article <?php post_class('post-block post-block--resource-library'); ?> id="post-<?php the_ID(); ?>">
-
-	<?php if ( has_post_thumbnail() ) : ?>
-    <a href="<?php the_permalink(); ?>" class="post-block__img" title="<?php the_title_attribute(); ?>">
-      <?php the_post_thumbnail( 'large' ); ?>
-    </a>
-	<?php endif; ?>
+<article <?php post_class($classes); ?> id="post-<?php the_ID(); ?>">
 
 	<?php
-		csisjti_display_categories();
+		csisjti_resource_format();
 	?>
 
 	<?php
 
-	the_title( '<h2 class="post-block__title text--semibold"><a href="' . esc_url( get_permalink() ) . '">', '</a></h2>' );
+	the_field( 'publication_date' );
 
-	csisjti_posted_on('M Y');
+	$url = get_field( 'url' );
+
+	if ( !$url ) {
+		the_title( '<h2 class="post-block__title">', '</h2>' );
+	} else {
+		the_title( '<h2 class="post-block__title"><a href="' . esc_url( $url ) . '">', '</a></h2>' );
+	}
+
+
+	csisjti_resource_authors();
+
+	csisjti_resource_organization();
+
+	the_field( 'description' );
+
+	the_field( 'summary' );
 
 	?>
 

--- a/wp-content/themes/csisjti/template-parts/block-post-resource-library.php
+++ b/wp-content/themes/csisjti/template-parts/block-post-resource-library.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Post Block for Resource Library content.
+ *
+ *
+ * @package CSIS iLab
+ * @subpackage @package CSISJTI
+ * @since 1.0.0
+ */
+
+?>
+
+<article <?php post_class('post-block post-block--resource-library'); ?> id="post-<?php the_ID(); ?>">
+
+	<?php if ( has_post_thumbnail() ) : ?>
+    <a href="<?php the_permalink(); ?>" class="post-block__img" title="<?php the_title_attribute(); ?>">
+      <?php the_post_thumbnail( 'large' ); ?>
+    </a>
+	<?php endif; ?>
+
+	<?php
+		csisjti_display_categories();
+	?>
+
+	<?php
+
+	the_title( '<h2 class="post-block__title text--semibold"><a href="' . esc_url( get_permalink() ) . '">', '</a></h2>' );
+
+	csisjti_posted_on('M Y');
+
+	?>
+
+	<p class="post-block__excerpt"> <?php echo get_the_excerpt(); ?></p>
+
+</article>


### PR DESCRIPTION
Closes #8 

This styles the Resource Block component. In order to properly test this, there's a couple of changes you'll need to make in the Admin Dashboard (sorry!).

- Change Custom Fields "Resource Library":
  - "Publication Date": change "Return Format" to "Custom: `M Y`"
  - "Publishing Organization": Change "Returns" to "Term Object"
  - "Description" --> "New Lines" to "Automatically add paragraphs"

A few other notes as you're reviewing:
- In the existing database, there is only ever one "Format" assigned, so I've only accounted for that use case. If there ever are more than 1, it'll default to comma separated list.
- This uses the `<details>` & `<summary>` tags to do the more/less details. Consequently, the button stays where it is when the details are expanded. I've confirmed this with Tucker and made some adjustments to the spacing accordingly that are different than what are in the mockups.
- I separated out the different kinds of post blocks into their own files, with common styles in `_post-block.scss` so we can make further changes more easily.
- I created a page for the resource archives and it's associated stylesheet. I changed the background according to the mockup, but didn't do any other page styling.
- I used CSS selector tricks for the external link (we only want the icon if it's external, not an internal link). I *think* I covered all the use cases, but we'll want to check that as we continue testing the site on different environments.
- For the "More/Less Details" I used pseudo elements to change the text. Normally I wouldn't recommend doing this because text in the `content: ''` property isn't accessible to screen readers, but since the details/summary element have that accessibility of letting users know if it's expanded or not built in and the default text for that is "Details", this felt acceptable to me.