### PR TITLE
Style fSelect facets on side bar

### DIFF
--- a/wp-content/themes/csisjti/archive-resource-library.php
+++ b/wp-content/themes/csisjti/archive-resource-library.php
@@ -12,13 +12,30 @@
 get_header();
 ?>
 
-	
+
 
 <main id="site-content" role="main">
 	<?php get_template_part( 'template-parts/entry-header' ); ?>
-	This is the resource library.
+
+	<div class="resource-library__secondary">
+		<h2>Search &amp; Filter</h2>
+		<?php
+			echo facetwp_display( 'facet', 'search_input' );
+			echo facetwp_display( 'facet', 'analysis_type' );
+			echo facetwp_display( 'facet', 'geographic_focus' );
+			echo facetwp_display( 'facet', 'sectors' );
+			echo facetwp_display( 'facet', 'focus_areas' );
+			echo facetwp_display( 'facet', 'format' );
+		?>
+		More Filters<br />
+		Clear All
+	</div>
+
+	<div class="resource-library__results">
 
 	<?php
+
+	echo facetwp_display( 'sort' );
 
 	if ( have_posts() ) {
 
@@ -30,6 +47,7 @@ get_header();
 	}
 
 	?>
+	</div>
 
 </main><!-- #site-content -->
 

--- a/wp-content/themes/csisjti/archive-resource-library.php
+++ b/wp-content/themes/csisjti/archive-resource-library.php
@@ -18,7 +18,7 @@ get_header();
 	<?php get_template_part( 'template-parts/entry-header' ); ?>
 
 	<div class="resource-library__secondary">
-		<h2>Search &amp; Filter</h2>
+		<h2 class="resource-library__subheading">Search &amp; Filter</h2>
 		<?php
 			echo facetwp_display( 'facet', 'search_input' );
 			echo facetwp_display( 'facet', 'analysis_type' );
@@ -27,15 +27,18 @@ get_header();
 			echo facetwp_display( 'facet', 'focus_areas' );
 			echo facetwp_display( 'facet', 'format' );
 		?>
-		More Filters<br />
-		Clear All
+		<button id="filters-btn" class="btn btn--outline btn--round btn--filters" data-a11y-dialog-show="accessible-dialog">
+			<?php
+				echo csisjti_get_svg( 'filter' );
+			?>
+			More Filters
+		</button>
+		<button id="filters-reset-btn" class="btn--reset" onclick="FWP.reset()">Clear All</button>
 	</div>
 
 	<div class="resource-library__results">
 
 	<?php
-
-	echo facetwp_display( 'sort' );
 
 	if ( have_posts() ) {
 

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
@@ -18,6 +18,34 @@
 
 .facetwp-input-wrap {
   display: block !important;
+  height: 100%;
+}
+
+.facetwp-search {
+  --input-background: #{$color-white-100};
+  --input-border: #{$color-gray-200};
+  width: 100%;
+  height: 100%;
+  padding: rem(8) rem(16) rem(8) rem(48) !important;
+  @extend %font-ui-text-lg;
+  background-color: var(--input-background);
+  border: 2px solid var(--input-border);
+  border-radius: 3px;
+
+  &::placeholder {
+    color: $color-black-140;
+  }
+}
+
+.facetwp-icon {
+  right: unset !important;
+  left: rem(16);
+  opacity: 0.4 !important;
+
+  &::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='icon-search' viewBox='0 0 34 32'%3E%3Cpath d='M22.627 25.234l6.18 6.172c0.78 0.792 2.040 0.792 2.82 0 0.784-0.79 0.784-2.068 0-2.86l-6.16-6.16c1.74-2.336 2.774-5.232 2.774-8.372 0-7.74-6.274-14.014-14.012-14.014-7.74 0-14.014 6.274-14.014 14.014s6.274 14.014 14.014 14.014c3.15 0 6.058-1.040 8.398-2.794zM14.227 24.024c-5.526 0-10.008-4.48-10.008-10.010 0-5.528 4.48-10.010 10.010-10.010 5.528 0 10.008 4.48 10.008 10.010 0 5.528-4.48 10.010-10.006 10.010h-0.004z'%3E%3C/path%3E%3C/svg%3E") !important;
+    animation: none !important;
+  }
 }
 
 /*----------  Facet: fSelect  ----------*/
@@ -112,7 +140,7 @@
     position: relative;
     top: 36%;
     height: 100%;
-    padding: rem(9) rem(72) rem(9) rem(16);
+    padding: rem(8) rem(72) rem(8) rem(16);
     overflow: hidden;
     color: $color-white-100;
     @extend %font-ui-text-lg-bold;

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
@@ -4,8 +4,7 @@
   &-facet {
     position: relative;
     height: rem(60);
-    margin: rem(12);
-    margin-bottom: 0 !important; // Override plugin default styles
+    margin-bottom: rem(12) !important; // Override plugin default styles
   }
 
   // Hides counters next to items
@@ -31,6 +30,12 @@
   background-color: var(--input-background);
   border: 2px solid var(--input-border);
   border-radius: 3px;
+
+  &:hover {
+    --input-border: #{$color-primary-blue-600};
+    box-shadow: 0 3px 4px rgba(2, 3, 3, 0.03), 0 3px 3px rgba(2, 3, 3, 0.02),
+      0 1px 8px rgba(2, 3, 3, 0.04);
+  }
 
   &::placeholder {
     color: $color-black-140;
@@ -256,8 +261,8 @@
       opacity: 0.4;
     }
 
-    h1 {
-      background-color: #f5f5f5;
+    &.d1 .fs-option-label {
+      padding-left: 0 !important; // Do not indent children checkboxes.
     }
   }
 

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
@@ -30,6 +30,7 @@
   background-color: var(--input-background);
   border: 2px solid var(--input-border);
   border-radius: 3px;
+  transition: background 0.3s ease-in-out, border 0.3s ease-in-out;
 
   &:hover {
     --input-border: #{$color-primary-blue-600};

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
@@ -1,0 +1,256 @@
+@use '../abstracts' as *;
+
+.facetwp {
+  &-facet {
+    position: relative;
+    height: rem(60);
+    margin: rem(12);
+    margin-bottom: 0 !important; // Override plugin default styles
+  }
+
+  // Hides counters next to items
+  &-counter {
+    display: none;
+  }
+}
+
+/*----------  Facet: Search  ----------*/
+
+.facetwp-input-wrap {
+  display: block !important;
+}
+
+/*----------  Facet: fSelect  ----------*/
+
+.fs {
+  &-wrap {
+    --input-background: #{$color-primary-blue-300};
+    --input-border: var(--input-background);
+    --arrow-color: #{$color-white-190};
+    position: relative;
+    display: inline-block;
+    line-height: 1;
+    cursor: pointer;
+
+    &:hover {
+      --input-border: #{$color-primary-blue-300};
+      --input-background: #{$color-primary-blue-200};
+    }
+
+    &.fs-default {
+      --input-background: #{$color-white-100};
+      --input-border: #{$color-gray-200};
+      --arrow-color: #{$color-black-190};
+
+      &:hover {
+        --input-border: #{$color-primary-blue-700};
+      }
+    }
+
+    .hidden {
+      display: none;
+    }
+  }
+
+  &-wrap,
+  &-label-wrap {
+    width: 100%;
+    height: 100%;
+  }
+
+  &-label-wrap {
+    position: relative;
+    background-color: var(--input-background);
+    border: 2px solid var(--input-border);
+    border-radius: 3px;
+    cursor: default;
+    transition: background 0.3s ease-in-out, border 0.3s ease-in-out;
+
+    &:hover {
+      filter: $shadow--3;
+    }
+
+    &:not([data-num='0'])::after {
+      content: attr(data-num);
+      position: absolute;
+      top: 50%;
+      right: 36px;
+      padding: rem(2) rem(8);
+      @extend %font-ui-text-sm;
+      font-weight: bold;
+      background: $color-white-100;
+      border-radius: 30px;
+      transform: translate(0, -50%);
+    }
+  }
+
+  &-label-wrap,
+  &-dropdown {
+    user-select: none;
+  }
+
+  &-label-field {
+    position: absolute;
+    top: 50%;
+    left: rem(16);
+    z-index: 1;
+    margin: 0;
+    color: $color-white-170;
+    @extend %font-ui-text-lg;
+    font-weight: normal;
+    transform: translate(0, -100%) scale(0.85);
+    transform-origin: left center;
+    pointer-events: none;
+
+    .fs-default & {
+      color: $color-black-190;
+      transform: translate(0, -50%) scale(1);
+    }
+  }
+
+  &-label {
+    position: relative;
+    top: 36%;
+    height: 100%;
+    padding: rem(9) rem(72) rem(9) rem(16);
+    overflow: hidden;
+    color: $color-white-100;
+    @extend %font-ui-text-lg-bold;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    .fs-default & {
+      top: unset;
+    }
+  }
+
+  &-arrow {
+    position: absolute;
+    top: 0;
+    right: rem(16);
+    bottom: 0;
+    width: 0;
+    height: 0;
+    margin: auto;
+    border-top: 5px solid var(--arrow-color);
+    border-right: 5px solid transparent;
+    border-left: 5px solid transparent;
+    transition: ease-in 0.15s;
+
+    .fs-open & {
+      transform: rotate(-180deg);
+    }
+  }
+
+  &-dropdown {
+    position: absolute;
+    z-index: 1000;
+    width: 100%;
+    margin: 0;
+    background-color: #fff;
+    border: 1px solid #ddd;
+
+    .fs-options {
+      max-height: 260px;
+      overflow: auto;
+    }
+  }
+
+  &-search {
+    padding: 0 8px;
+    border-bottom: 1px solid #eee;
+
+    input {
+      width: 100%;
+      padding: 6px 0;
+      border: 0;
+      outline: none;
+      box-shadow: none !important;
+    }
+  }
+
+  &-option,
+  &-search,
+  &-optgroup-label,
+  &-no-results {
+    padding: rem(12);
+    cursor: default;
+  }
+
+  &-option {
+    --checkbox-bg: #{$color-gray-field};
+    --checkbox-border: #{$color-gray-100};
+    position: relative;
+    display: flex;
+    gap: rem(12);
+    line-height: 1.15;
+    word-break: break-all;
+    cursor: pointer;
+
+    &:hover {
+      --checkbox-bg: #{$color-primary-blue-800};
+      --checkbox-border: #{$color-primary-blue-700};
+      background: $color-gray-field;
+
+      i {
+        border-width: 2px;
+      }
+    }
+
+    &.selected {
+      --checkbox-bg: #{$color-primary-blue-400};
+      --checkbox-border: #{$color-primary-blue-300};
+
+      i::before {
+        --borderWidth: 2px;
+        --height: 10px;
+        --width: 5px;
+        --borderColor: #{$color-white-100};
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        display: block;
+        width: var(--width);
+        height: var(--height);
+        border-right: var(--borderWidth) solid var(--borderColor);
+        border-bottom: var(--borderWidth) solid var(--borderColor);
+        transform: translate(-50%, -60%) rotate(45deg);
+      }
+    }
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    &.disabled {
+      cursor: default;
+      opacity: 0.4;
+    }
+
+    h1 {
+      background-color: #f5f5f5;
+    }
+  }
+
+  &-optgroup-label {
+    font-weight: bold;
+    text-align: center;
+    background-color: #f8f8f8;
+  }
+
+  &-checkbox {
+    display: block;
+
+    i {
+      position: relative;
+      display: block;
+      width: 1.2em;
+      height: 1.2em;
+      margin: auto;
+      background-color: var(--checkbox-bg);
+      border: 1px solid var(--checkbox-border);
+      border-radius: 4px;
+    }
+  }
+}

--- a/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
@@ -8,4 +8,34 @@
   &__secondary {
     max-width: 33%;
   }
+
+  &__subheading {
+    margin: 0 0 rem(8);
+    color: $color-black-170;
+    @extend %font-ui-text-sm-bold-uppercase;
+    letter-spacing: 0.5px;
+  }
+}
+
+.btn {
+  &--filters {
+    margin-top: rem(12);
+    margin-bottom: rem(12);
+  }
+
+  &--reset {
+    display: block;
+    padding: rem(8);
+    color: $color-black-155;
+    @extend %font-ui-text-sm;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    transition: color 0.3s ease-in-out;
+    appearance: none;
+
+    &:hover {
+      color: $color-black-190;
+    }
+  }
 }

--- a/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
@@ -3,3 +3,9 @@
 .post-type-archive-resource-library {
   background: $color-gray-100;
 }
+
+.resource-library {
+  &__secondary {
+    max-width: 33%;
+  }
+}

--- a/wp-content/themes/csisjti/assets/_scss/style.scss
+++ b/wp-content/themes/csisjti/assets/_scss/style.scss
@@ -7,6 +7,7 @@
 @use 'base/utilities';
 @use 'components/buttons';
 @use 'components/cta';
+@use 'components/facets';
 @use 'components/media';
 @use 'components/event-block';
 @use 'components/entry-header';

--- a/wp-content/themes/csisjti/assets/plugins/facets.js
+++ b/wp-content/themes/csisjti/assets/plugins/facets.js
@@ -1,0 +1,26 @@
+;(function ($) {
+  $(document).on('facetwp-loaded', function () {
+    modifyFSelectFacet()
+  })
+
+  function modifyFSelectFacet() {
+    console.log(FWP)
+
+    $('.facetwp-type-fselect').each(function () {
+      const $facet = $(this)
+      const facet_name = $facet.attr('data-name')
+      const facet_label = FWP.settings.labels[facet_name]
+
+      // Add Facet Label
+      const label = document.createElement('div')
+      label.classList.add('fs-label-field')
+      label.innerHTML = facet_label
+
+      this.querySelector('.fs-label-wrap').prepend(label)
+
+      // Add Number of Selected Options to Wrapper
+      const numSelected = FWP.facets[facet_name].length
+      this.querySelector('.fs-label-wrap').setAttribute('data-num', numSelected)
+    })
+  }
+})(jQuery)

--- a/wp-content/themes/csisjti/assets/plugins/facets.js
+++ b/wp-content/themes/csisjti/assets/plugins/facets.js
@@ -1,11 +1,13 @@
+/* eslint no-undef: 0 */
+
 ;(function ($) {
   $(document).on('facetwp-loaded', function () {
     modifyFSelectFacet()
+
+    console.log('hello! world')
   })
 
   function modifyFSelectFacet() {
-    console.log(FWP)
-
     $('.facetwp-type-fselect').each(function () {
       const $facet = $(this)
       const facet_name = $facet.attr('data-name')

--- a/wp-content/themes/csisjti/gulp.config.js
+++ b/wp-content/themes/csisjti/gulp.config.js
@@ -8,6 +8,7 @@ module.exports = {
   src: './src',
   dest: './dist',
   php: './**/*.php',
+  pluginsJS: './assets/plugins/**/*.js',
 
   port: 8080,
 

--- a/wp-content/themes/csisjti/gulpfile.js
+++ b/wp-content/themes/csisjti/gulpfile.js
@@ -43,6 +43,8 @@ const watcher = () => {
   watch(config.assets + config.js.src + '/**/*', series(webpack, reload))
 
   watch(config.php, reload) // Reload on PHP file changes.
+
+  watch(config.pluginsJS, reload) // Reload on plugin JS file changes.
 }
 
 // Clean dist folder
@@ -50,9 +52,9 @@ function clean() {
   return del([
     config.assets + config.sass.dest,
     config.assets + config.js.dest,
-		config.imagemin.dest,
-		config.sass.mainStyleSheetDest + '*.css',
-		config.sass.mainStyleSheetDest + '*.css.map'
+    config.imagemin.dest,
+    config.sass.mainStyleSheetDest + '*.css',
+    config.sass.mainStyleSheetDest + '*.css.map',
   ])
 }
 

--- a/wp-content/themes/csisjti/inc/template-functions.php
+++ b/wp-content/themes/csisjti/inc/template-functions.php
@@ -421,12 +421,25 @@ if ( class_exists( 'easyFootnotes' ) ) {
 * Strips additional p tags placed in html when using ACF wsywg
 */
 function the_field_without_wpautop( $field_name ) {
-	
+
 	remove_filter('acf_the_content', 'wpautop');
-	
+
 	the_field( $field_name );
-	
+
 	add_filter('acf_the_content', 'wpautop');
-	
+
 }
 
+/**
+ * Modify the assets that are loaded on pages that use facets.
+ */
+add_filter( 'facetwp_assets', function( $assets ) {
+		$assets['custom.js'] = '/wp-content/themes/csisjti/assets/plugins/facets.js';
+		unset( $assets['fSelect.css'] );
+    return $assets;
+});
+
+/**
+ * Add accessibility JS for facets.
+ */
+add_filter( 'facetwp_load_a11y', '__return_true' );

--- a/wp-content/themes/csisjti/search.php
+++ b/wp-content/themes/csisjti/search.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * The main template file
+ *
+ * This is the most generic template file in a WordPress theme
+ * and one of the two required files for a theme (the other being style.css).
+ * It is used to display a page when nothing more specific matches a query.
+ * E.g., it puts together the home page when no home.php file exists.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package WordPress
+ * @subpackage CSISJTI
+ * @since 1.0.0
+ */
+
+get_header();
+?>
+
+<main id="site-content" role="main">
+<?php get_template_part( 'template-parts/entry-header' ) ?>
+	<?php
+
+	$archive_title    = '';
+	$archive_subtitle = '';
+
+	if ( is_search() ) {
+		global $wp_query;
+
+		$archive_title = sprintf(
+			'%1$s %2$s',
+			'<span class="color-accent">' . __( 'Search:', 'csisjti' ) . '</span>',
+			'&ldquo;' . get_search_query() . '&rdquo;'
+		);
+
+		if ( $wp_query->found_posts ) {
+			$archive_subtitle = sprintf(
+				/* translators: %s: Number of search results */
+				_n(
+					'We found %s result for your search.',
+					'We found %s results for your search.',
+					$wp_query->found_posts,
+					'csisjti'
+				),
+				number_format_i18n( $wp_query->found_posts )
+			);
+		} else {
+			$archive_subtitle = __( 'We could not find any results for your search. You can give it another try through the search form below.', 'csisjti' );
+		}
+	} elseif ( ! is_home() ) {
+		$archive_title    = get_the_archive_title();
+		$archive_subtitle = get_the_archive_description();
+	}
+
+	if ( $archive_title || $archive_subtitle ) {
+		?>
+
+		<header class="archive-header has-text-align-center header-footer-group">
+
+			<div class="archive-header-inner section-inner medium">
+
+				<?php if ( $archive_title ) { ?>
+					<h1 class="archive-title"><?php echo wp_kses_post( $archive_title ); ?></h1>
+				<?php } ?>
+
+				<?php if ( $archive_subtitle ) { ?>
+					<div class="archive-subtitle section-inner thin max-percentage intro-text"><?php echo wp_kses_post( wpautop( $archive_subtitle ) ); ?></div>
+				<?php } ?>
+
+			</div><!-- .archive-header-inner -->
+
+		</header><!-- .archive-header -->
+
+		<?php
+	}
+
+	if ( have_posts() ) {
+
+		while ( have_posts() ) {
+			the_post();
+
+			get_template_part( 'template-parts/block-post', get_post_type() );
+
+		}
+	} elseif ( is_search() ) {
+		?>
+
+		<div class="no-search-results-form section-inner thin">
+
+			<?php
+			get_search_form(
+				array(
+					'label' => __( 'search again', 'csisjti' ),
+				)
+			);
+			?>
+
+		</div><!-- .no-search-results -->
+
+		<?php
+	}
+	?>
+
+	<?php get_template_part( 'template-parts/pagination' ); ?>
+
+</main><!-- #site-content -->
+
+<?php
+get_footer();


### PR DESCRIPTION
Begins styling the filters on the side of the resources archive (#22).

In order to work with the Facets JS, I added a new `plugins` subfolder to our `assets` directory. This includes a JS file specifically for the Facets and has access to the Facets object.

Some notes:
- This does not properly implement the page layout with the sidebar. I'm going to do that next in a separate PR.
- Because FacetWP works via Ajax, I did not include the various "Apply" or "Search" buttons that are included in the mockup.
- Likewise, I had to make a few small tweaks to the design as I implemented to fit the structure.
- I noticed that I forgot to do the Analysis Format on the resource card - I'll add it on a separate a PR.
- The "More Filters" button doesn't open the correct modal. I thought we could look at that together as we merge in our different pieces.
- The CSS for the facets will likely need to be refactored as we add in the other parts of it.