### PR TITLE
Resource Tabs

### DIFF
--- a/wp-content/themes/csisjti/assets/_scss/abstracts/_variables.scss
+++ b/wp-content/themes/csisjti/assets/_scss/abstracts/_variables.scss
@@ -56,6 +56,9 @@ $color-gradient-blue: rgba(2, 186, 198, 1);
 $color-gradient-yellow: rgba(144, 53, 180, 1);
 $color-gradient-purple: rgba(106, 38, 138, 1);
 
+$color-jti-analysis: $color-primary-green-500;
+$color-essential-reading: $color-primary-yellow-400;
+
 /*----------  Fonts  ----------*/
 $font-roboto: 'Roboto', sans-serif;
 $font-barlow: 'Barlow', sans-serif;

--- a/wp-content/themes/csisjti/assets/_scss/abstracts/_variables.scss
+++ b/wp-content/themes/csisjti/assets/_scss/abstracts/_variables.scss
@@ -59,6 +59,9 @@ $color-gradient-purple: rgba(106, 38, 138, 1);
 $color-jti-analysis: $color-primary-green-500;
 $color-essential-reading: $color-primary-yellow-400;
 
+$color-tabs-inactive: #b1c3d0;
+$color-tabs-hover: #92b7d2;
+
 /*----------  Fonts  ----------*/
 $font-roboto: 'Roboto', sans-serif;
 $font-barlow: 'Barlow', sans-serif;

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets-tabs.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets-tabs.scss
@@ -1,0 +1,108 @@
+@use '../abstracts' as *;
+
+.facetwp {
+  &-facet-type_of_content {
+    --tab-width: 16px;
+    display: flex;
+    grid-column: 1;
+    grid-row: 9;
+    width: calc(100% + var(--container-padding) + var(--tab-width) + 2vw);
+    margin-top: rem(16);
+    margin-right: calc(var(--container-padding) * -1);
+    margin-bottom: 0 !important;
+    margin-left: calc(var(--container-padding) * -1);
+    padding-left: calc(var(--tab-width) + 2px);
+    overflow: scroll;
+    color: $color-black-100;
+    @extend %font-ui-text-lg;
+
+    @include breakpoint('large') {
+      grid-row: 7;
+      width: initial;
+      margin-right: auto;
+      margin-left: 0;
+      overflow: hidden;
+    }
+
+    .facetwp-counter {
+      color: $color-black-170;
+      @extend %font-ui-text-sm;
+    }
+  }
+
+  &-radio {
+    --tab-bg: #{$color-primary-blue-700};
+    position: relative;
+    z-index: 1;
+    display: flex;
+    gap: rem(8);
+    justify-content: center;
+    align-items: center;
+    // min-width: rem(125);
+    margin-right: var(--tab-width);
+    margin-bottom: 0 !important;
+    margin-left: var(--tab-left);
+    padding: rem(12) calc(#{rem(16)} + var(--tab-width)) !important;
+    white-space: nowrap;
+    background-color: var(--tab-bg) !important;
+    background-image: none !important;
+    border-radius: 4px 4px 0 0;
+    transition: background-color 0.3s ease-in-out;
+
+    &.checked {
+      --tab-bg: #{$color-gray-300};
+      z-index: 2;
+      font-weight: bold;
+    }
+
+    &:hover,
+    &:focus {
+      --tab-bg: #{$color-primary-blue-600};
+    }
+
+    &[data-value='jti_analysis'] {
+      --color: #{$color-jti-analysis};
+    }
+
+    &[data-value='essential_reading'] {
+      --color: #{$color-essential-reading};
+    }
+
+    // Tabs
+    &::after {
+      content: '';
+      position: absolute;
+      top: 2px;
+      right: calc(var(--tab-width) * -1);
+      bottom: -1px;
+      left: calc(var(--tab-width) * -1);
+      z-index: -1;
+      display: block;
+      background: var(--tab-bg);
+      transition: background 0.3s ease-in-out;
+      /* stylelint-disable */
+      clip-path: polygon(
+        calc(var(--tab-width) + 1px) 0%,
+        calc(100% - var(--tab-width) - 1px) 0%,
+        100% 100%,
+        0% 100%
+      );
+      /* stylelint-enable */
+
+      @include breakpoint('medium') {
+        bottom: 0;
+      }
+    }
+
+    // Ribbon
+    &::before {
+      content: '';
+      width: 10px;
+      height: 18px;
+      border: 6px solid var(--color, $color-black-100);
+      border-top: 0;
+      border-bottom: 5px solid transparent;
+      border-radius: 2px 2px 0 0;
+    }
+  }
+}

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets-tabs.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets-tabs.scss
@@ -24,85 +24,85 @@
       overflow: hidden;
     }
 
-    .facetwp-counter {
-      color: $color-black-170;
-      @extend %font-ui-text-sm;
-    }
-  }
+    .facetwp-radio {
+      --tab-bg: #{$color-primary-blue-700};
+      position: relative;
+      z-index: 1;
+      display: flex;
+      gap: rem(8);
+      justify-content: center;
+      align-items: center;
+      // min-width: rem(125);
+      margin-right: var(--tab-width);
+      margin-bottom: 0 !important;
+      margin-left: var(--tab-left);
+      padding: rem(12) calc(#{rem(16)} + var(--tab-width)) !important;
+      white-space: nowrap;
+      background-color: var(--tab-bg) !important;
+      background-image: none !important;
+      border-radius: 4px 4px 0 0;
+      transition: background-color 0.3s ease-in-out;
 
-  &-radio {
-    --tab-bg: #{$color-primary-blue-700};
-    position: relative;
-    z-index: 1;
-    display: flex;
-    gap: rem(8);
-    justify-content: center;
-    align-items: center;
-    // min-width: rem(125);
-    margin-right: var(--tab-width);
-    margin-bottom: 0 !important;
-    margin-left: var(--tab-left);
-    padding: rem(12) calc(#{rem(16)} + var(--tab-width)) !important;
-    white-space: nowrap;
-    background-color: var(--tab-bg) !important;
-    background-image: none !important;
-    border-radius: 4px 4px 0 0;
-    transition: background-color 0.3s ease-in-out;
+      &.checked {
+        --tab-bg: #{$color-gray-300};
+        z-index: 2;
+        font-weight: bold;
+      }
 
-    &.checked {
-      --tab-bg: #{$color-gray-300};
-      z-index: 2;
-      font-weight: bold;
-    }
+      &:hover,
+      &:focus {
+        --tab-bg: #{$color-primary-blue-600};
+      }
 
-    &:hover,
-    &:focus {
-      --tab-bg: #{$color-primary-blue-600};
-    }
+      &[data-value='jti_analysis'] {
+        --color: #{$color-jti-analysis};
+      }
 
-    &[data-value='jti_analysis'] {
-      --color: #{$color-jti-analysis};
-    }
+      &[data-value='essential_reading'] {
+        --color: #{$color-essential-reading};
+      }
 
-    &[data-value='essential_reading'] {
-      --color: #{$color-essential-reading};
-    }
+      // Tabs
+      &::after {
+        content: '';
+        position: absolute;
+        top: 0.5px;
+        right: calc(var(--tab-width) * -1);
+        bottom: -1px;
+        left: calc(var(--tab-width) * -1);
+        z-index: -1;
+        display: block;
+        background: var(--tab-bg);
+        transition: background 0.3s ease-in-out;
+        /* stylelint-disable */
+        clip-path: polygon(
+          calc(var(--tab-width) + 1px) 0%,
+          calc(100% - var(--tab-width) - 1px) 0%,
+          100% 100%,
+          0% 100%
+        );
+        /* stylelint-enable */
 
-    // Tabs
-    &::after {
-      content: '';
-      position: absolute;
-      top: 0.5px;
-      right: calc(var(--tab-width) * -1);
-      bottom: -1px;
-      left: calc(var(--tab-width) * -1);
-      z-index: -1;
-      display: block;
-      background: var(--tab-bg);
-      transition: background 0.3s ease-in-out;
-      /* stylelint-disable */
-      clip-path: polygon(
-        calc(var(--tab-width) + 1px) 0%,
-        calc(100% - var(--tab-width) - 1px) 0%,
-        100% 100%,
-        0% 100%
-      );
-      /* stylelint-enable */
+        @include breakpoint('large') {
+          bottom: 0;
+        }
+      }
 
-      @include breakpoint('large') {
-        bottom: 0;
+      // Ribbon
+      &::before {
+        content: '';
+        width: 10px;
+        height: 18px;
+        border: 6px solid var(--color, $color-black-100);
+        border-top: 0;
+        border-bottom: 5px solid transparent;
+        border-radius: 2px 2px 0 0;
       }
     }
 
-    // Ribbon
-    &::before {
-      content: '';
-      width: 10px;
-      height: 18px;
-      border: 6px solid var(--color, $color-black-100);
-      border-top: 0;
-      border-bottom: 5px solid transparent;
-      border-radius: 2px 2px 0 0;
+    .facetwp-counter {
+      color: $color-black-170;
+      @extend %font-ui-text-sm;
     }
   }
 }

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets-tabs.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets-tabs.scss
@@ -72,7 +72,7 @@
     &::after {
       content: '';
       position: absolute;
-      top: 2px;
+      top: 0.5px;
       right: calc(var(--tab-width) * -1);
       bottom: -1px;
       left: calc(var(--tab-width) * -1);
@@ -89,7 +89,7 @@
       );
       /* stylelint-enable */
 
-      @include breakpoint('medium') {
+      @include breakpoint('large') {
         bottom: 0;
       }
     }

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets-tabs.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets-tabs.scss
@@ -25,14 +25,13 @@
     }
 
     .facetwp-radio {
-      --tab-bg: #{$color-primary-blue-700};
+      --tab-bg: #{$color-tabs-inactive};
       position: relative;
       z-index: 1;
       display: flex;
       gap: rem(8);
       justify-content: center;
       align-items: center;
-      // min-width: rem(125);
       margin-right: var(--tab-width);
       margin-bottom: 0 !important;
       margin-left: var(--tab-left);
@@ -51,7 +50,7 @@
 
       &:hover,
       &:focus {
-        --tab-bg: #{$color-primary-blue-600};
+        --tab-bg: #{$color-tabs-hover};
       }
 
       &[data-value='jti_analysis'] {

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
@@ -22,14 +22,14 @@
   }
 
   &.is-essential-reading,
-  &.is-jti-content {
+  &.is-jti-analysis {
     #{$post}__header {
       margin-top: rem(16);
     }
   }
 
   &.is-essential-reading::before,
-  &.is-jti-content::after {
+  &.is-jti-analysis::after {
     content: '';
     position: absolute;
     top: 0;
@@ -45,7 +45,7 @@
     --color: #{$color-primary-green-500};
   }
 
-  &.is-jti-content {
+  &.is-jti-analysis {
     &.is-essential-reading::before {
       right: calc(var(--padding-sides) + 1.5rem);
     }

--- a/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_post-block-resource-library.scss
@@ -36,13 +36,14 @@
     right: var(--padding-sides);
     width: 16px;
     height: 24px;
-    border: 8px solid var(--color, $color-primary-yellow-400);
+    border: 8px solid var(--color, $color-jti-analysis);
     border-top: 0;
     border-bottom: 6px solid transparent;
+    border-radius: 2px 2px 0 0;
   }
 
   &.is-essential-reading::before {
-    --color: #{$color-primary-green-500};
+    --color: #{$color-essential-reading};
   }
 
   &.is-jti-analysis {

--- a/wp-content/themes/csisjti/assets/_scss/layout/_header.scss
+++ b/wp-content/themes/csisjti/assets/_scss/layout/_header.scss
@@ -5,7 +5,7 @@
   top: 0;
   right: 0;
   left: 0;
-  z-index: 2;
+  z-index: 10;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;

--- a/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
@@ -1,7 +1,9 @@
 @use '../abstracts' as *;
+@use '../components/facets-tabs';
 
 :root {
   --top-bar-height: #{rem(72)};
+  --page-header-bg: #015d91; // TODO: make this a variable
 }
 
 .post-type-archive-resource-library {
@@ -9,6 +11,13 @@
 
   .entry-header {
     margin-bottom: 0;
+    padding-bottom: 0;
+
+    .cta {
+      @include breakpoint('large') {
+        margin-bottom: rem(24);
+      }
+    }
   }
 
   .is-highlighted {

--- a/wp-content/themes/csisjti/inc/template-tags.php
+++ b/wp-content/themes/csisjti/inc/template-tags.php
@@ -376,9 +376,9 @@ if (! function_exists('csisjti_resource_date')) :
 
 	}
 endif;
-		
+
 /**
- * Displays Resource Description. 
+ * Displays Resource Description.
  *
  *
  * @return string $html The description.
@@ -436,6 +436,29 @@ if (! function_exists('csisjti_resource_authors')) :
 
 		printf( '<div class="post-block__authors"><dt class="post-meta__label">By</dt><dd class="post-meta__value">' . esc_html__( '%1$s', 'csisjti' ) . '</dd></div>', implode(', ', $authors ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
+	}
+endif;
+
+/**
+ * Generates classes for Resource Block if it's a JTI analysis or Essential Reading.
+ *
+ *
+ * @return string $html The authors.
+ */
+if (! function_exists('csisjti_resource_content_type')) :
+	function csisjti_resource_content_type() {
+		$type_of_content = get_field( 'type_of_content' );
+
+		if ( !$type_of_content ) {
+			return;
+		}
+
+		$classes = '';
+		foreach( $type_of_content as $type ) {
+			$classes .= ' is-' . str_replace('_', '-', $type);
+		}
+
+		return $classes;
 	}
 endif;
 
@@ -522,7 +545,7 @@ if (! function_exists('csisjti_resource_sectors')) :
 	}
 endif;
 
-/** 
+/**
  * Displays Resource Keywords.
  *
  *
@@ -546,7 +569,7 @@ if (! function_exists('csisjti_resource_keywords')) :
 	}
 endif;
 
-/** 
+/**
  * Displays Resource Geographic Focus.
  *
  *
@@ -582,7 +605,7 @@ if (! function_exists('csisjti_resource_geographic_focus')) :
 	}
 endif;
 
-/** 
+/**
  * Displays Resource Focus Areas.
  *
  *

--- a/wp-content/themes/csisjti/template-parts/block-post-resource-library.php
+++ b/wp-content/themes/csisjti/template-parts/block-post-resource-library.php
@@ -10,13 +10,9 @@
 
  $classes = 'post-block post-block--resource-library';
 
- if ( get_field( 'is_essential_reading' ) == 1 ) {
-	$classes .= ' is-essential-reading';
- }
+ $specialClasses = csisjti_resource_content_type();
 
- if ( get_field( 'is_just_transition_initiative_content' ) == 1 ) {
-	 $classes .= ' is-jti-content';
- }
+ $classes .= $specialClasses;
 
 ?>
 

--- a/wp-content/themes/csisjti/template-parts/entry-header.php
+++ b/wp-content/themes/csisjti/template-parts/entry-header.php
@@ -12,7 +12,7 @@ $entry_header_classes = '';
 ?>
 
 <header class="entry-header<?php echo esc_attr( $entry_header_classes ); ?>">
-    
+
 	<?php
 	csisjti_share();
 
@@ -23,7 +23,7 @@ $entry_header_classes = '';
 	csisjti_display_categories();
 
 	csisjti_header_subtitle();
-  
+
 	if (get_post_type() == 'event') {
 
 		csisjti_last_updated();
@@ -31,33 +31,35 @@ $entry_header_classes = '';
 		get_template_part( 'template-parts/event-block-upcoming' );
 	?>
 		<!-- past event block -->
-		 
-		<?php $related_analysis = get_field( 'related_analysis' ); 
-		if ( $related_analysis ) : 
-			$post = $related_analysis;  
+
+		<?php $related_analysis = get_field( 'related_analysis' );
+		if ( $related_analysis ) :
+			$post = $related_analysis;
 		 	setup_postdata( $post ); ?>
 			<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
-			<?php wp_reset_postdata(); 
-		endif; 
+			<?php wp_reset_postdata();
+		endif;
 		?>
 
 	<?php } else if ( has_post_thumbnail() ) { ?>
 		<div class="post-block__img"><?php the_post_thumbnail( 'large' ); ?></div>
-			
+
 		<?php
 		get_template_part( 'template-parts/featured-image-caption' );
 
 		if (get_post_type() == 'post') { csisjti_posted_on(); }
 
 	} else if ((get_post_type() == 'resource-library')) {
-		
+
+		echo facetwp_display( 'facet', 'type_of_content' );
+
 	?>
 		<button id="classification-btn" class="entry-header__icon" data-a11y-dialog-show="accessible-dialog" ><?php echo csisjti_get_svg('info'); ?>Classifications</button>
 
-		<a href="" class="cta cta--white">What is "Just Transition"? 
+		<a href="" class="cta cta--white">What is "Just Transition"?
 			<?php echo csisjti_get_svg( 'arrow-right' ); ?>
 		</a>
-		
+
 	<?php } ?>
 
 </header><!-- .entry-header -->


### PR DESCRIPTION
A part of #22, this adds the tabs along the top of the page. Note that PR #39 should be reviewed first (and please let me know once you've looked at it and I can rebase this branch just to make sure nothing is out of sync).

You'll need to pull down the database from Dev as I had to modify how the Is JTI Analysis/Essential Reading are selected. I also added a new facet (radio buttons) to handle the switch. I scoped the CSS for these though, so hopefully it shouldn't conflict with any radio buttons you've implemented.

Note that I've based the tab colors off of what is in the components section of the mockups, but they need to be reviewed by Tucker since the page header gradient for the Resource Library changed to blue instead of green.