### PR TITLE
Fix is_home conditional for categories & date

### DIFF
--- a/wp-content/themes/csisjti/inc/template-tags.php
+++ b/wp-content/themes/csisjti/inc/template-tags.php
@@ -154,7 +154,7 @@ function csisjti_formatted_title( $post_id = false ) {
 function csisjti_posted_on( $date_format = null ) {
 
 	// Require post ID.
-	if ( is_home() || ! get_the_ID() ) {
+	if ( ! get_the_ID() ) {
 		return;
 	}
 
@@ -238,7 +238,7 @@ if (! function_exists('csisjti_display_categories')) :
 	function csisjti_display_categories() {
 
 		// Require post ID.
-		if ( is_home() || ! get_the_ID() ) {
+		if ( ! get_the_ID() ) {
 			return;
 		}
 

--- a/wp-content/themes/csisjti/template-parts/entry-header.php
+++ b/wp-content/themes/csisjti/template-parts/entry-header.php
@@ -34,7 +34,9 @@ if ( !$is_home && $has_thumbnail ) {
 	csisjti_share();
 
 	// Display either the categories or the page content type.
-	csisjti_display_categories();
+	if ( !$is_home ) {
+		csisjti_display_categories();
+	}
 	csisjti_display_page_content_type();
 
 	// Archives & Pages have a specially formatted title.
@@ -48,7 +50,7 @@ if ( !$is_home && $has_thumbnail ) {
 
 	csisjti_header_description( $post_id );
 
-	if ( $post_type == 'post') {
+	if ( !$is_home && $post_type == 'post') {
 		csisjti_posted_on();
 	}
 


### PR DESCRIPTION
My previous changes introduced a bug where the category or date weren't showing up. I've fixed it by amending the logic to exclude the blog page.