### PR TITLE
Bug/resource sort tabs

### DIFF
--- a/wp-content/themes/csisjti/assets/plugins/facets.js
+++ b/wp-content/themes/csisjti/assets/plugins/facets.js
@@ -237,7 +237,8 @@
   // Calculates the number of active filters applied.
   function setNumFilters() {
     // We don't want the pagination or sort to imapct the count.
-    const excludedFacets = ['pagination', 'sort']
+    console.log(FWP.facets)
+    const excludedFacets = ['pagination', 'sort', 'paged']
 
     const numFilters = Object.keys(FWP.facets)
       .filter((f) => !excludedFacets.includes(f))

--- a/wp-content/themes/csisjti/assets/plugins/facets.js
+++ b/wp-content/themes/csisjti/assets/plugins/facets.js
@@ -14,6 +14,7 @@
     customizeDatePicker()
     connectFacets()
     hideExtraFacets()
+    enableAutoRefreshSpecificFacets()
     hasRun = true
   })
 
@@ -235,12 +236,17 @@
 
   // Calculates the number of active filters applied.
   function setNumFilters() {
-    const numFilters = Object.values(FWP.facets).reduce((acc, curr) => {
-      if (curr != '' && !Array.isArray(curr)) {
-        return acc + 1
-      }
-      return acc + curr.length
-    }, 0)
+    // We don't want the pagination or sort to imapct the count.
+    const excludedFacets = ['pagination', 'sort']
+
+    const numFilters = Object.keys(FWP.facets)
+      .filter((f) => !excludedFacets.includes(f))
+      .reduce((acc, curr) => {
+        if (FWP.facets[curr] != '' && !Array.isArray(FWP.facets[curr])) {
+          return acc + 1
+        }
+        return acc + FWP.facets[curr].length
+      }, 0)
 
     Array.from(numFiltersApplied).forEach((el) => (el.innerHTML = numFilters))
   }
@@ -350,5 +356,20 @@
       var $parent = $('.facetwp-facet-' + key).closest('.facet-wrap')
       0 === val ? $parent.hide() : $parent.show()
     })
+  }
+
+  // We want to refresh as soon as the user changes the type of content (tabs) or changes the sort order.
+  function enableAutoRefreshSpecificFacets() {
+    $(document).on('change', '.facetwp-sort-select', function () {
+      FWP.refresh()
+    })
+
+    $(document).on(
+      'click',
+      '.facetwp-facet-type_of_content .facetwp-radio',
+      function () {
+        FWP.refresh()
+      }
+    )
   }
 })(jQuery)


### PR DESCRIPTION
Resolves bugs in #59 related to sort & tabs not working. By disabling the autorefresh, I accidentally overlooked that these two facets would no longer work. I've added listeners so the refresh function is called when either of those is changed.

I also adjusted the "# of filters applied" counter so it doesn't count sorting or pagination.