### PR TITLE
Feat/filter dropdown revamp

### DIFF
--- a/wp-content/themes/csisjti/assets/_scss/components/_filters-modal.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_filters-modal.scss
@@ -313,65 +313,6 @@ $facet: '.facetwp-facet';
   .facetwp-type-fselect {
     max-width: 66%;
     margin-bottom: rem(40) !important;
-
-    .fs-wrap {
-      position: relative;
-    }
-
-    .fs-dropdown {
-      top: 0;
-
-      &.hidden {
-        /* stylelint-disable-next-line */
-        .fs-search {
-          display: block !important;
-        }
-      }
-    }
-
-    // Overrides inherit hidden styling to show the search bar on modal load
-    .fs-show {
-      display: block !important;
-    }
-
-    // Toggles dropdown display state
-    .fs-active {
-      /* stylelint-disable */
-      .fs-options {
-        display: block;
-      }
-
-      .fs-no-results {
-        display: none;
-      }
-
-      .fs-search {
-        &::after {
-          transform: rotate(-180deg);
-        }
-        /* stylelint-enable */
-      }
-    }
-
-    .fs-search {
-      position: relative;
-
-      &::after {
-        position: absolute;
-        top: 0;
-        right: 1rem;
-        bottom: 0;
-        width: 0;
-        height: 0;
-        margin: auto;
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='icon-arrow-down' viewBox='0 0 26 32'%3E%3Cpath d='M25.657 18.254l-2.664-2.664-8.087 8.087v-23.265h-3.767v23.265l-8.087-8.087-2.664 2.664 12.634 12.634 12.634-12.634z'%3E%3C/path%3E%3C/svg%3E");
-        border-top: 5px solid $color-black-190;
-        border-right: 5px solid transparent;
-        border-left: 5px solid transparent;
-        transition: 0.15s ease-in;
-        content: '';
-      }
-    }
   }
 
   /*----------  Facet: Custom Date Range  ----------*/

--- a/wp-content/themes/csisjti/assets/_scss/components/_filters-modal.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_filters-modal.scss
@@ -315,6 +315,10 @@ $facet: '.facetwp-facet';
     margin-bottom: rem(40) !important;
   }
 
+  .fs-fselect-apply {
+    display: none;
+  }
+
   /*----------  Facet: Custom Date Range  ----------*/
 
   #{$facet}-publish_date {

--- a/wp-content/themes/csisjti/assets/_scss/components/_modal.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_modal.scss
@@ -19,7 +19,7 @@ dialog[open] {
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 2;
+  z-index: 11;
   background-color: rgba(0, 0, 0, 0.66);
 }
 
@@ -32,6 +32,7 @@ dialog::backdrop {
   top: 50%;
   left: 50%;
   max-height: 100%;
+  z-index: 12;
   overflow: auto;
   background: $color-white-100;
   border: unset;

--- a/wp-content/themes/csisjti/assets/plugins/facets.js
+++ b/wp-content/themes/csisjti/assets/plugins/facets.js
@@ -8,6 +8,7 @@
     modifySearchFacet()
     fSelectFacetApply()
     modifyFSelectFacet()
+    modifyFSelectLabels()
     modifyExpandIcons()
     setNumFilters()
     fwpDisableAutoRefresh()
@@ -342,6 +343,16 @@
       '.facetwp-facet-type_of_content .facetwp-radio',
       function () {
         FWP.refresh()
+      }
+    )
+  }
+
+  function modifyFSelectLabels() {
+    $('.filters-modal .facetwp-type-fselect').each(
+      function () {
+        let el = this.querySelectorAll('.fs-label-field')[0]
+        let label = el.innerText.replace(" Modal", "")
+        el.innerText = label
       }
     )
   }

--- a/wp-content/themes/csisjti/assets/plugins/facets.js
+++ b/wp-content/themes/csisjti/assets/plugins/facets.js
@@ -6,6 +6,7 @@
   $(document).on('facetwp-loaded', function () {
     modifyCheckboxes()
     modifySearchFacet()
+    fSelectFacetApply()
     modifyFSelectFacet()
     modifyExpandIcons()
     setNumFilters()
@@ -150,7 +151,13 @@
         label.innerHTML = facet_label
 
         this.querySelector('.fs-label-wrap').prepend(label)
+      }
+    )
+  }
 
+  function fSelectFacetApply() {
+    $('.resource-library__inline-filters .facetwp-type-fselect').each(
+      function () {
         // Add Apply Button
         const applyWrapper = document.createElement('div')
         applyWrapper.classList.add('fs-fselect-apply')

--- a/wp-content/themes/csisjti/assets/plugins/facets.js
+++ b/wp-content/themes/csisjti/assets/plugins/facets.js
@@ -7,7 +7,6 @@
     modifyCheckboxes()
     modifySearchFacet()
     modifyFSelectFacet()
-    modifyMultiSelect()
     modifyExpandIcons()
     setNumFilters()
     fwpDisableAutoRefresh()
@@ -127,7 +126,7 @@
   }
 
   function modifyFSelectFacet() {
-    $('.resource-library__inline-filters .facetwp-type-fselect').each(
+    $('.facetwp-type-fselect').each(
       function () {
         const $facet = $(this)
         const facet_name = $facet.attr('data-name')
@@ -180,40 +179,6 @@
       span.innerHTML = '<i></i>'
 
       this.prepend(span)
-    })
-  }
-
-  function modifyMultiSelect() {
-    $('.filters-modal .facetwp-type-fselect').each(function () {
-      this.querySelector('.fs-dropdown').classList.remove('hidden')
-      this.querySelector('.fs-dropdown').classList.add('fs-show')
-      this.querySelector('.fs-options').classList.add('hidden')
-
-      this.querySelector('.fs-search input').setAttribute(
-        'placeholder',
-        'Type here to filter list'
-      )
-
-      // Close dropdown on outside click
-      $('.filters-modal').on('click', function () {
-        $('.fs-active').each(function () {
-          if ($(this)[0].classList.contains('fs-active')) {
-            $(this)[0].classList.remove('fs-active')
-          }
-        })
-      })
-
-      // Logic to open dropdown or close on self-click
-      $('.fs-search', this).on('click', function (event) {
-        const fs_wrap = $(this).parents('.fs-wrap')[0]
-
-        if (fs_wrap.classList.contains('fs-active')) {
-          fs_wrap.classList.remove('fs-active')
-        } else {
-          event.stopPropagation()
-          fs_wrap.classList.add('fs-active')
-        }
-      })
     })
   }
 


### PR DESCRIPTION
1. Revert dropdowns to original styling (same styling as inline filters on resource lib page)

2. Resolve bug that does not allow you to use filter modal on firefox and safari 