### PR TITLE
Only show default image on posts

### DIFF
--- a/wp-content/themes/csisjti/inc/template-functions.php
+++ b/wp-content/themes/csisjti/inc/template-functions.php
@@ -571,5 +571,17 @@ function set_posts_per_page( $query ) {
   return $query;
 }
 
+/**
+ * Only use default feature image on posts.
+ */
+function csisjti_dfi_posttype_post ( $dfi_id, $post_id ) {
+	$post = get_post($post_id);
+
+  if ( 'post' === $post->post_type ) {
+    return $dfi_id; // the original featured image id
+  }
+  return 0; // the original featured image id
+}
+add_filter( 'dfi_thumbnail_id', 'csisjti_dfi_posttype_post', 10, 2 );
 
 


### PR DESCRIPTION
We added the plugin to set a default image for analysis posts. This enforces that it only applies to analysis posts and not other parts of the site. Like this lol https://csisjtidev.wpengine.com/about/