### PR TITLE
Set overflow to scroll on inline filters

### DIFF
--- a/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
@@ -5,8 +5,8 @@
 
 /* stylelint-disable */
 .resource-library__inline-filters {
-  height media query {
-    max-height: 500px;
+  // Set overflow scroll on the inline filters so on small screens you can always access the dropdown options & the more filters/clear button. They are cut off on shorter screens + when more filters are selected & added to the list.
+  @include breakpoint('large') {
     overflow: scroll;
   }
 }
@@ -18,9 +18,9 @@
     height: rem(60);
     margin-bottom: rem(12) !important; // Override plugin default styles
 
-    @media all and (max-height: 800px) {
+    @media screen and (max-height: 800px) {
       height: rem(45);
-      margin-bottom: 0.50rem!important;
+      margin-bottom: 0.5rem !important;
     }
   }
 
@@ -314,7 +314,7 @@
     &.d1 .fs-option-label {
       padding-left: 0 !important; // Do not indent children checkboxes.
     }
-    
+
     .fs-option-label {
       white-space: normal !important;
       word-break: break-word;

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
@@ -7,7 +7,7 @@
 .resource-library__inline-filters {
   // Set overflow scroll on the inline filters so on small screens you can always access the dropdown options & the more filters/clear button. They are cut off on shorter screens + when more filters are selected & added to the list.
   @include breakpoint('large') {
-    overflow: scroll;
+    overflow-y: scroll;
   }
 }
 

--- a/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_facets.scss
@@ -5,8 +5,8 @@
 
 /* stylelint-disable */
 .resource-library__inline-filters {
-  // Set overflow scroll on the inline filters so on small screens you can always access the dropdown options & the more filters/clear button. They are cut off on shorter screens + when more filters are selected & added to the list.
-  @include breakpoint('large') {
+  // Set overflow scroll on the inline filters so on shorter screens you can always access the dropdown options & the more filters/clear button. They are cut off on shorter screens + when more filters are selected & added to the list.
+  @media screen and (min-width: 64em) and (max-height: 1000px) {
     overflow-y: scroll;
   }
 }
@@ -15,12 +15,12 @@
 .resource-library__inline-filters .facetwp {
   &-facet {
     position: relative;
-    height: rem(60);
-    margin-bottom: rem(12) !important; // Override plugin default styles
+    height: rem(45);
+    margin-bottom: 0.5rem !important;
 
-    @media screen and (max-height: 800px) {
-      height: rem(45);
-      margin-bottom: 0.5rem !important;
+    @media screen and (min-height: 1000px) {
+      height: rem(60);
+      margin-bottom: rem(12) !important; // Override plugin default styles
     }
   }
 


### PR DESCRIPTION
This should resolve the error we were having where the addition of new filter fields or opening up a dropdown was falling off the screen and you couldn't access it. I've set the overflow-y to scroll, so if you open up a dropdown or new filters are added, a scrollbar is immediately added so you can always access everything. I also adjusted the height/margin media query so everything gets bigger after 1000px (just reversed the order so it's small screen first, then larger screen) and bumped up the min height from 800px to 1000px.

<img width="628" alt="Screen Shot 2020-11-20 at 3 01 00 PM" src="https://user-images.githubusercontent.com/1896496/99846550-855a7300-2b44-11eb-8104-96acf072d565.png">
