### PR TITLE
Properly calculates the scrollbar size

### DIFF
--- a/wp-content/themes/csisjti/assets/_scss/abstracts/_mixins.scss
+++ b/wp-content/themes/csisjti/assets/_scss/abstracts/_mixins.scss
@@ -144,7 +144,7 @@
 
 @mixin csisjti-full-width-wrapper {
   @include vw100;
-  margin-left: calc(50% - (50vw - var(--scrollbar)));
+  margin-left: calc(50% - (50vw - var(--scrollbarHalf)));
 }
 
 @mixin csisjti-full-width-content {

--- a/wp-content/themes/csisjti/assets/_scss/base/_base.scss
+++ b/wp-content/themes/csisjti/assets/_scss/base/_base.scss
@@ -2,8 +2,8 @@
 @use 'sass:map';
 
 :root {
-  /* stylelint-disable-next-line*/
-  --scrollbar: 0px;
+  --scrollbar: var(--scrollbarX);
+  --scrollbarHalf: calc(var(--scrollbar) / 2);
   --header-height: 72px;
   --logo-height: 55px;
   --event-block-height: 112px;
@@ -28,7 +28,7 @@
 
 .container {
   --container-padding: 6vw;
-  
+
   position: relative;
   max-width: $size__container-max-width;
   margin-right: auto;

--- a/wp-content/themes/csisjti/assets/_scss/components/_entry-header.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_entry-header.scss
@@ -44,7 +44,7 @@
     bottom: 0;
     z-index: -1;
     @include vw100;
-    margin-left: calc(50% - (50vw - var(--scrollbar)));
+    margin-left: calc(50% - (50vw - var(--scrollbarHalf)));
     background: var(--page-header-bg);
     background-repeat: no-repeat;
     // Separate values for the Image, Gradient, and solid color, respectfully.

--- a/wp-content/themes/csisjti/assets/_scss/components/_explore-resource-widget.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_explore-resource-widget.scss
@@ -2,7 +2,7 @@
 
 .explore-resource-library {
   @include vw100;
-  margin-left: calc(50% - (50vw - var(--scrollbar)));
+  margin-left: calc(50% - (50vw - var(--scrollbarHalf)));
   padding: rem(40) var(--container-padding);
   color: $color-white-190;
   /* stylelint-disable */
@@ -33,7 +33,7 @@
 
     &:hover {
       color: $color-white-100;
-      
+
       .icon {
         color: $color-primary-blue-400;
         background: $color-white-100;
@@ -41,7 +41,7 @@
       }
     }
   }
-  
+
   .icon {
     flex-shrink: 0;
     width: 2em;

--- a/wp-content/themes/csisjti/assets/_scss/pages/event.scss
+++ b/wp-content/themes/csisjti/assets/_scss/pages/event.scss
@@ -143,7 +143,7 @@
     @include vw100;
     height: 1px;
     margin-bottom: rem(42);
-    margin-left: calc(50% - (50vw - var(--scrollbar)));
+    margin-left: calc(50% - (50vw - var(--scrollbarHalf)));
     background: $color-gray-line;
   }
 

--- a/wp-content/themes/csisjti/assets/_scss/pages/home.scss
+++ b/wp-content/themes/csisjti/assets/_scss/pages/home.scss
@@ -80,7 +80,7 @@ $tab-gradient: linear-gradient(180deg, #018085 0%, #018576 100%);
         bottom: 0;
         display: block;
         @include vw100;
-        margin-left: calc(50% - (50vw - var(--scrollbar)));
+        margin-left: calc(50% - (50vw - var(--scrollbarHalf)));
         overflow: hidden;
       }
 
@@ -91,7 +91,7 @@ $tab-gradient: linear-gradient(180deg, #018085 0%, #018576 100%);
         bottom: 0;
         z-index: 1;
         @include vw100;
-        margin-left: calc(50% - (50vw - var(--scrollbar)));
+        margin-left: calc(50% - (50vw - var(--scrollbarHalf)));
         background: var(--page-header-home);
         mix-blend-mode: soft-light;
         pointer-events: none;
@@ -99,7 +99,7 @@ $tab-gradient: linear-gradient(180deg, #018085 0%, #018576 100%);
 
       video {
         @include breakpoint('xlarge') {
-          width: 100vw;
+          @include vw100;
         }
       }
     }
@@ -132,7 +132,7 @@ $tab-gradient: linear-gradient(180deg, #018085 0%, #018576 100%);
         bottom: 0;
         left: calc(100% - var(--filter-width));
         z-index: 1;
-        width: calc(50vw - var(--scrollbar) / 2 - 50% + var(--filter-width));
+        width: calc(50vw - var(--scrollbarHalf) - 50% + var(--filter-width));
         background: $tab-gradient;
       }
     }
@@ -179,7 +179,7 @@ $tab-gradient: linear-gradient(180deg, #018085 0%, #018576 100%);
       bottom: 0;
       left: 0;
       z-index: -1;
-      width: calc(100vw - var(--scrollbar) - var(--container-padding));
+      width: calc(100vw - var(--scrollbarHalf) - var(--container-padding));
       background: $tab-gradient;
 
       @include breakpoint('large') {
@@ -250,7 +250,11 @@ $tab-gradient: linear-gradient(180deg, #018085 0%, #018576 100%);
         bottom: 0;
         left: 100%;
         z-index: -1;
-        width: calc(100vw - var(--scrollbar) - 100% - var(--container-padding));
+        /* stylelint-disable */
+        width: calc(
+          100vw - var(--scrollbarHalf) - 100% - var(--container-padding)
+        );
+        /* stylelint-enable */
         height: 100%;
         background: $tab-solid;
 
@@ -329,7 +333,7 @@ $tab-gradient: linear-gradient(180deg, #018085 0%, #018576 100%);
           top: 0;
           right: 100%;
           display: block;
-          width: calc(50vw - var(--scrollbar) / 2 - 50%);
+          width: calc(50vw - var(--scrollbarHalf) - 50%);
           height: 100%;
           background: $color-gray-400;
         }
@@ -523,7 +527,7 @@ $tab-gradient: linear-gradient(180deg, #018085 0%, #018576 100%);
       bottom: 0;
       z-index: -1;
       @include vw100;
-      margin-left: calc(50% - (50vw - var(--scrollbar)));
+      margin-left: calc(50% - (50vw - var(--scrollbarHalf)));
       background: $color-banner-bg;
     }
 
@@ -545,7 +549,6 @@ $tab-gradient: linear-gradient(180deg, #018085 0%, #018576 100%);
       flex-direction: column;
       grid-area: date;
       margin: rem(32) auto;
-
 
       @include breakpoint(large) {
         grid-column: 2;

--- a/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
+++ b/wp-content/themes/csisjti/assets/_scss/pages/resource-library.scss
@@ -128,7 +128,7 @@
     justify-content: space-between;
     align-items: center;
     @include vw100;
-    margin-left: calc(50% - (50vw - var(--scrollbar)));
+    margin-left: calc(50% - (50vw - var(--scrollbarHalf)));
     padding: rem(32) var(--container-padding) rem(12);
     background: $color-gray-300;
     box-shadow: 0 4px 5px rgba(2, 3, 3, 0.03), 0 1px 10px rgba(2, 3, 3, 0.02),


### PR DESCRIPTION
* Sets the `--scrollbar` variable: it was never updating and always set to 0
* When used in the margin calculations, the value needs to be divided in 2 to account for left/right side, so I created a `--scrollbarHalf` value that was used in place of `--scrollbar` when applied to `margin-left`.

Note to us: we should probably make a mixin that handles this for us in future projects. Maybe extending the `100vw` mixin by including the margin left stuff, or making a new one that includes it. We use that pattern quite a bit.

@urchykli FYI as this might be an issue that pops up in the MT project too.