### PR TITLE
Bug/filter num values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# CSIS*Mag*
+# Just Transitions Initiative
 
-The website for the CSIS*Mag* study by CSIS iDeas Lab. It is based off of the TwentyTwenty WordPress theme and gulp, Sass, Autoprefixer, PostCSS, imagemin, and Browsersync to speed-up development.
+The website for the Just Transitions Initiative. It is based off of the TwentyTwenty WordPress theme and gulp, Sass, Autoprefixer, PostCSS, imagemin, and Browsersync to speed-up development.
 
 ## Table of Contents
 

--- a/wp-content/themes/csisjti/README.md
+++ b/wp-content/themes/csisjti/README.md
@@ -53,9 +53,9 @@ $ npm start
 
 TravisCI will automatically run when pull requests are submitted. If successful:
 
-- Pull requests into `development` will be deployed to the [WP Engine Development Environment](https://csismtdev.wpengine.com/). The Development environment should be used to demo new features to programs. Once approved, a pull request should be submitted to `main`.
+- Pull requests into `development` will be deployed to the [WP Engine Development Environment](https://csisjtidev.wpengine.com/). The Development environment should be used to demo new features to programs. Once approved, a pull request should be submitted to `main`.
 
-- Pull requests in `main` will be deployed to the [WP Engine Staging Environment](http://csismtstaging.wpengine.com/). The Staging environment should be used as a launchpad to add new features to Production.
+- Pull requests in `main` will be deployed to the [WP Engine Staging Environment](https://csisjtistaging.wpengine.com/). The Staging environment should be used as a launchpad to add new features to Production.
 
 ### See More Commands
 

--- a/wp-content/themes/csisjti/assets/_scss/components/_modal.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_modal.scss
@@ -83,11 +83,12 @@ dialog::backdrop {
 
   * {
     max-width: 680px;
+    margin: 0 auto;
   }
 
   &__heading {
     @extend %font-ui-section-heading-lg;
-    margin: rem(12) 0 rem(40);
+    margin: rem(12) auto rem(40);
   }
 
   &__desc {

--- a/wp-content/themes/csisjti/assets/plugins/facets.js
+++ b/wp-content/themes/csisjti/assets/plugins/facets.js
@@ -147,8 +147,13 @@
 
       // Add Number of Selected Options to Wrapper
       const numSelected = FWP.facets[facet_name].length
-      this.querySelector('.fs-label-wrap').setAttribute('data-num', numSelected)
+      const noResults = document.querySelector('.no-results__heading')
 
+      // Remove data attribute on no search results
+      if (!noResults) {
+        this.querySelector('.fs-label-wrap').setAttribute('data-num', numSelected)
+      }
+      
       // If these fields already exist, don't create them again.
       if (this.querySelector('.fs-label-field')) {
         return


### PR DESCRIPTION
1. Remove num values only on no search results
2. Update readme's
3. Classification modal was at 100% width - we had made this decision due to bugs caused on the filter modal. This resulted in the classification modal content being pulled to the left side with whitespace on the right. Margins were adjusted to reposition the content. 