### PR TITLE
Comment out caption code that displays at the end of the analysis con…

### DIFF
--- a/wp-content/themes/csisjti/template-parts/featured-image-caption.php
+++ b/wp-content/themes/csisjti/template-parts/featured-image-caption.php
@@ -14,6 +14,6 @@ if ( has_post_thumbnail() && ! post_password_required() ) {
 	$caption = get_the_post_thumbnail_caption();
 
 	if ( $caption ) {
-		echo '<div class="featured-media__caption"> ' . esc_html( $caption ) . '</div>';
+		// echo '<div class="featured-media__caption"> ' . esc_html( $caption ) . '</div>';
 	}
 }


### PR DESCRIPTION
Remove additional caption code that displays a second caption at the end of the analysis content. Commenting this out for now in case there is another use case for this file. 

