### PR TITLE
Add margin to top of modal to ensure visibility of apply button

### DIFF
--- a/wp-content/themes/csisjti/assets/_scss/components/_modal.scss
+++ b/wp-content/themes/csisjti/assets/_scss/components/_modal.scss
@@ -34,6 +34,7 @@ dialog::backdrop {
   z-index: 12;
   width: 100%;
   max-height: 100%;
+  margin-top: rem(80);
   overflow: auto;
   background: $color-white-100;
   border: unset;


### PR DESCRIPTION
Add margin to top of modal to ensure visibility of entire modal. 

Bug: Top row of Filter Modal including apply button not visible for smaller desktop sizes and on mobile. Uncertain why this occurred. Believe that a margin-top will resolve this issue. The amount of margin was determined so that you users could see the JTI logo and navbar above the modal within the overlay. 