### PR TITLE
Parse registration link field

### DIFF
--- a/wp-content/themes/csisjti/inc/template-tags.php
+++ b/wp-content/themes/csisjti/inc/template-tags.php
@@ -883,7 +883,7 @@ if (! function_exists('csisjti_event_register_link')) :
 			return;
 		}
 
-		$registration_link = get_field( 'registration_link' );
+		$registration_link = preg_replace("(^https?://)", "", get_field( 'registration_link' ) );
 
 		if ( !$registration_link ) {
 			return;


### PR DESCRIPTION
Bug Description:

The registration link was broken. HTTPS:// was being inserted 2x into the url. 

Resolution:

Parse the ACF registration in the code. 